### PR TITLE
Use IMDSv2, allow disabling Docker container access to metadata endpoint

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.0
+module_version: 1.1.0
 
 tests:
   - name: Set up in the default VPC

--- a/asg.tf
+++ b/asg.tf
@@ -34,15 +34,15 @@ poweroff
 
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   name    = local.namespace
   lc_name = local.namespace
 
-  image_id             = var.ami_id
-  instance_type        = var.ec2_instance_type
-  security_groups      = var.security_groups
-  iam_instance_profile = aws_iam_instance_profile.this.arn
+  image_id                 = var.ami_id
+  instance_type            = var.ec2_instance_type
+  security_groups          = var.security_groups
+  iam_instance_profile_arn = aws_iam_instance_profile.this.arn
 
   root_block_device = [
     {
@@ -52,7 +52,6 @@ module "asg" {
   ]
 
   # Auto scaling group
-  asg_name                  = local.namespace
   wait_for_capacity_timeout = 0
   termination_policies      = ["OldestLaunchConfiguration"]
   vpc_zone_identifier       = var.vpc_subnets
@@ -75,6 +74,12 @@ module "asg" {
       local.user_data_tail,
     ])
   )
+
+  metadata_options = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = var.assume_role_in_docker ? 2 : 1
+  }
 
   tags = concat(var.tags, [
     {

--- a/examples/default-vpc/main.tf
+++ b/examples/default-vpc/main.tf
@@ -9,12 +9,13 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-data "aws_security_group" "this" {
-  name = "default"
-}
-
 data "aws_vpc" "this" {
   default = true
+}
+
+data "aws_security_group" "this" {
+  name   = "default"
+  vpc_id = data.aws_vpc.this.id
 }
 
 data "aws_subnet_ids" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,15 @@ variable "ami_id" {
   default     = "ami-09c3c03b344b3e2c2"
 }
 
+variable "assume_role_in_docker" {
+  type        = bool
+  description = <<EOF
+  Indicates whether the role can be assumed by jobs running in Docker
+  containers. This adds an extra allowed hop to IMDSv2 PUT response limit.
+  EOF
+  default     = true
+}
+
 variable "configuration" {
   type        = string
   description = <<EOF
@@ -38,7 +47,7 @@ variable "security_groups" {
 }
 
 variable "tags" {
-  type        = list
+  type        = list(any)
   description = "List of tags to set on the resources"
   default     = []
 }


### PR DESCRIPTION
## Description of the change

Blocked by [an upstream problem](https://github.com/terraform-aws-modules/terraform-aws-autoscaling/issues/147).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
