### PR TITLE
Automatically run security update

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.1
+module_version: 1.0.2
 
 tests:
   - name: Set up in the default VPC

--- a/asg.tf
+++ b/asg.tf
@@ -9,6 +9,9 @@ set -e
   EOF
 
   user_data_tail = <<EOF
+echo "Updating packages (security)" >> /var/log/spacelift/info.log
+yum update-minimal --security -y 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
+
 echo "Downloading Spacelift launcher" >> /var/log/spacelift/info.log
 curl https://downloads.${var.domain_name}/spacelift-launcher --output /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
 


### PR DESCRIPTION
## Description of the change

The idea here is that updating security packages may take a while and will slow down the start of the machine, but it's otherwise not super practical to build a new AMI every time we have a new CVE and have everyone update their configs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
