### PR TITLE
Switch to new AMI

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.6
+module_version: 1.0.7
 
 tests:
   - name: Set up in the default VPC

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "ami_id" {
   type        = string
   description = "ID of the Spacelift AMI"
-  default     = "ami-09c3c03b344b3e2c2"
+  default     = "ami-0e3b6f010d24a7e3f"
 }
 
 variable "configuration" {


### PR DESCRIPTION
The AMI was actually fine, and I'd just made a mistake when testing in our environments. Switching the default back to the latest AMI.

The AMI comes from https://github.com/spacelift-io/spacelift-worker-image/releases/tag/0.2.0.

## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
