### PR TITLE
Assorted performance and security changes (1.1.0)

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 1.0.8
+module_version: 2.0.0
 
 tests:
   - name: Set up in the default VPC

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.0.0
+module_version: 1.1.0
 
 tests:
   - name: Set up in the default VPC

--- a/ami.tf
+++ b/ami.tf
@@ -1,8 +1,12 @@
 data "aws_ami" "this" {
-  executable_users = ["self"]
-  most_recent      = true
-  name_regex       = "^spacelift-\\d{10}$"
-  owners           = ["643313122712"]
+  most_recent = true
+  #   name_regex       = "^spacelift-\\d{10}"
+  owners = ["643313122712"]
+
+  filter {
+    name   = "name"
+    values = ["spacelift-*"]
+  }
 
   filter {
     name   = "root-device-type"

--- a/ami.tf
+++ b/ami.tf
@@ -1,0 +1,16 @@
+data "aws_ami" "this" {
+  executable_users = ["self"]
+  most_recent      = true
+  name_regex       = "^spacelift-\\d{10}$"
+  owners           = ["643313122712"]
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}

--- a/ami.tf
+++ b/ami.tf
@@ -1,12 +1,7 @@
 data "aws_ami" "this" {
   most_recent = true
-  #   name_regex       = "^spacelift-\\d{10}"
-  owners = ["643313122712"]
-
-  filter {
-    name   = "name"
-    values = ["spacelift-*"]
-  }
+  name_regex  = "^spacelift-\\d{10}$"
+  owners      = ["643313122712"]
 
   filter {
     name   = "root-device-type"

--- a/asg.tf
+++ b/asg.tf
@@ -71,10 +71,11 @@ module "asg" {
   use_lc    = true
   create_lc = true
 
+  iam_instance_profile_name = aws_iam_instance_profile.this.arn
   image_id                  = var.ami_id != "" ? var.ami_id : data.aws_ami.this.id
   instance_type             = var.ec2_instance_type
+  placement_tenancy         = "default"
   security_groups           = var.security_groups
-  iam_instance_profile_name = aws_iam_instance_profile.this.name
 
   root_block_device = [
     {

--- a/asg.tf
+++ b/asg.tf
@@ -79,7 +79,7 @@ module "asg" {
 
   root_block_device = [
     {
-      encrypted   = true
+      encrypted   = var.volume_encryption
       volume_size = var.volume_size
       volume_type = "gp3"
     },

--- a/asg.tf
+++ b/asg.tf
@@ -66,29 +66,35 @@ poweroff
 
 module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   name    = local.namespace
   lc_name = local.namespace
 
-  image_id             = var.ami_id
-  instance_type        = var.ec2_instance_type
-  security_groups      = var.security_groups
-  iam_instance_profile = aws_iam_instance_profile.this.arn
+  use_lc    = true
+  create_lc = true
+
+  image_id                  = var.ami_id
+  instance_type             = var.ec2_instance_type
+  security_groups           = var.security_groups
+  iam_instance_profile_name = aws_iam_instance_profile.this.name
 
   root_block_device = [
     {
       volume_size = var.volume_size
-      volume_type = "gp2"
+      volume_type = "gp3"
     },
   ]
 
   # Auto scaling group
-  asg_name                  = local.namespace
   wait_for_capacity_timeout = 0
   termination_policies = [
     "OldestLaunchConfiguration", # First look at the oldest launch configuration.
     "OldestInstance",            # When that has not changed, kill oldest instances first.
+  ]
+  enabled_metrics = [
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
   ]
   vpc_zone_identifier = var.vpc_subnets
 

--- a/asg.tf
+++ b/asg.tf
@@ -120,11 +120,6 @@ module "asg" {
     ])
   )
 
-  tags = concat(var.tags, [
-    {
-      key                 = "WorkerPoolID"
-      value               = var.worker_pool_id
-      propagate_at_launch = true
-    }
-  ])
+  tags        = var.tags
+  tags_as_map = { "WorkerPoolID" : var.worker_pool_id }
 }

--- a/asg.tf
+++ b/asg.tf
@@ -78,6 +78,7 @@ module "asg" {
 
   root_block_device = [
     {
+      encrypted   = true
       volume_size = var.volume_size
       volume_type = "gp3"
     },

--- a/asg.tf
+++ b/asg.tf
@@ -85,14 +85,13 @@ module "asg" {
 
   # Auto scaling group
   wait_for_capacity_timeout = 0
+
   termination_policies = [
     "OldestLaunchConfiguration", # First look at the oldest launch configuration.
     "OldestInstance",            # When that has not changed, kill oldest instances first.
   ]
-  enabled_metrics = [
-    "GroupDesiredCapacity",
-    "GroupInServiceInstances",
-  ]
+
+  enabled_metrics     = var.enabled_metrics
   vpc_zone_identifier = var.vpc_subnets
 
   health_check_grace_period = 30

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,11 +9,11 @@ output "instances_role_name" {
 }
 
 output "autoscaling_group_arn" {
-  value       = module.asg.this_autoscaling_group_arn
+  value       = module.asg.autoscaling_group_arn
   description = "ARN of the auto scaling group"
 }
 
 output "launch_configuration_id" {
-  value       = module.asg.this_launch_configuration_id
+  value       = module.asg.launch_configuration_id
   description = "ID of the launch configuration"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,6 +38,21 @@ variable "ec2_instance_type" {
   default     = "t3.micro"
 }
 
+variable "enabled_metrics" {
+  type        = list(string)
+  description = "List of CloudWatch metrics enabled on the ASG"
+  default = [
+    "GroupDesiredCapacity",
+    "GroupInServiceInstances",
+    "GroupMaxSize",
+    "GroupMinSize",
+    "GroupPendingInstances",
+    "GroupStandbyInstances",
+    "GroupTerminatingInstances",
+    "GroupTotalInstances",
+  ]
+}
+
 variable "min_size" {
   type        = number
   description = "Minimum numbers of workers to spin up"

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,12 @@ variable "tags" {
   default     = []
 }
 
+variable "volume_encryption" {
+  type        = bool
+  default     = false
+  description = "Whether to encrypt the EBS volume"
+}
+
 variable "volume_size" {
   type        = number
   default     = 40

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "ami_id" {
   type        = string
   description = "ID of the Spacelift AMI"
-  default     = "ami-0e3b6f010d24a7e3f"
+  default     = ""
 }
 
 variable "configuration" {
@@ -12,6 +12,18 @@ variable "configuration" {
   Store, Vault etc. Ultimately, here you need to export SPACELIFT_TOKEN and
   SPACELIFT_POOL_PRIVATE_KEY to the environment.
   EOF
+}
+
+variable "disable_container_credentials" {
+  type        = bool
+  description = <<EOF
+  If true, the run container will not be able to access the instance profile
+  credentials by talking to the EC2 metadata endpoint. This is done by setting
+  the number of hops in IMDSv2 to 1. Since the Docker container goes through an
+  extra NAT step, this still allows the launcher to talk to the endpoint, but
+  prevents the container from doing so.
+  EOF
+  default     = false
 }
 
 variable "domain_name" {


### PR DESCRIPTION
## Description of the change

### Changes:

- we're now pulling the latest AMI ID dynamically and using it if the explicit ID is not provided;
- the instance will no longer run security updates on startup - instead, we assume that the newer AMI will be used (immutability FTW);
- we're switching to gp3 for the volume type - according to AWS _top performance of gp3 is four times faster than the maximum throughput of gp2 volumes_;
- we're adding the option to encrypt the disk;
- we're switching to and enforcing [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html), and adding support for disabling the endpoint for run containers (by setting max hops to 1);
- we're allowing users to override CloudWatch metrics generated by the ASG;

That's probably more than enough to bump the minor version.

## Type of change

- [x] New feature (non-breaking change that adds functionality);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
