### PR TITLE
Allow delaying EC2 instance power-off

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ $ make docs
 | <a name="input_iam_role_arn"></a> [iam\_role\_arn](#input\_iam\_role\_arn) | ARN of an existing IAM to use. Used `when create_iam_role` = `false` | `string` | `null` | no |
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of workers to spin up | `number` | `10` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum numbers of workers to spin up | `number` | `0` | no |
+| <a name="input_poweroff_delay"></a> [poweroff\_delay](#input\_poweroff\_delay) | Number of seconds to wait before powering the EC2 instance off after the Spacelift launcher stopped | `number` | `15` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | List of security groups to use | `list(string)` | n/a | yes |
 | <a name="input_volume_encryption"></a> [volume\_encryption](#input\_volume\_encryption) | Whether to encrypt the EBS volume | `bool` | `false` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of instance EBS volume | `number` | `40` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -68,8 +68,8 @@ echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
 )}
 
 spacelift
-echo "Powering off in 15 seconds" >> /var/log/spacelift/error.log
-sleep 15
+echo "Powering off in ${var.poweroff_delay} seconds" >> /var/log/spacelift/error.log
+sleep ${var.poweroff_delay}
 poweroff
   EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -77,6 +77,12 @@ variable "max_size" {
   default     = 10
 }
 
+variable "poweroff_delay" {
+  type        = number
+  description = "Number of seconds to wait before powering the EC2 instance off after the Spacelift launcher stopped"
+  default     = 15
+}
+
 variable "security_groups" {
   type        = list(string)
   description = "List of security groups to use"


### PR DESCRIPTION
## Description of the change

Allow delaying EC2 instance power-off. This is mainly meant to extend that delay to get enough time to troubleshoot an issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
