### PR TITLE
Adjust resource base name logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ make docs
 | <a name="input_volume_encryption_kms_key_id"></a> [volume\_encryption\_kms\_key\_id](#input\_volume\_encryption\_kms\_key\_id) | KMS key ID to use for encrypting the EBS volume | `string` | `null` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of instance EBS volume | `number` | `40` | no |
 | <a name="input_vpc_subnets"></a> [vpc\_subnets](#input\_vpc\_subnets) | List of VPC subnets to use | `list(string)` | n/a | yes |
-| <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | ID of the the worker pool. It is used for the naming convention of the resources. | `string` | n/a | yes |
+| <a name="input_worker_pool_id"></a> [worker\_pool\_id](#input\_worker\_pool\_id) | ID (ULID) of the the worker pool. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ $ make docs
 | <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Additional tags to set on the resources | `map(string)` | `{}` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | ID of the Spacelift AMI. If left empty, the latest Spacelift AMI will be used. | `string` | `""` | no |
 | <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"v0.2.0"` | no |
+| <a name="input_base_name"></a> [base\_name](#input\_base\_name) | Base name for resources. If unset, it defaults to `sp5ft-${var.worker_pool_id}`. | `string` | `null` | no |
 | <a name="input_configuration"></a> [configuration](#input\_configuration) | User configuration. This allows you to decide how you want to pass your token<br>  and private key to the environment - be that directly, or using SSM Parameter<br>  Store, Vault etc. Ultimately, here you need to export SPACELIFT\_TOKEN and<br>  SPACELIFT\_POOL\_PRIVATE\_KEY to the environment. | `string` | n/a | yes |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
 | <a name="input_custom_iam_role_name"></a> [custom\_iam\_role\_name](#input\_custom\_iam\_role\_name) | Name of an existing IAM to use. Used `when create_iam_role` = `false` | `string` | `""` | no |

--- a/asg.tf
+++ b/asg.tf
@@ -78,7 +78,7 @@ module "asg" {
   source  = "terraform-aws-modules/autoscaling/aws"
   version = "~> 6.0"
 
-  name = local.namespace
+  name = local.base_name
 
   iam_instance_profile_arn = aws_iam_instance_profile.this.arn
   image_id                 = var.ami_id != "" ? var.ami_id : data.aws_ami.this.id

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -1,5 +1,5 @@
 locals {
-  function_name = "${local.namespace}-ec2-autoscaler"
+  function_name = "${local.base_name}-ec2-autoscaler"
 }
 
 resource "aws_ssm_parameter" "spacelift_api_key_secret" {

--- a/iam.tf
+++ b/iam.tf
@@ -14,7 +14,7 @@ locals {
 
 resource "aws_iam_role" "this" {
   count = var.create_iam_role ? 1 : 0
-  name  = local.namespace
+  name  = local.base_name
   path  = "/"
 
   assume_role_policy = jsonencode({
@@ -44,7 +44,7 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_iam_instance_profile" "this" {
   depends_on = [aws_iam_role_policy_attachment.this]
 
-  name = local.namespace
+  name = local.base_name
   role = var.create_iam_role ? aws_iam_role.this[0].name : var.custom_iam_role_name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,3 @@
+locals {
+  base_name = var.base_name == null ? "sp5ft-${var.worker_pool_id}" : var.base_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,17 @@ variable "vpc_subnets" {
 variable "worker_pool_id" {
   type        = string
   description = "ID of the the worker pool. It is used for the naming convention of the resources."
+  validation {
+    condition     = can(regex("^[0-9A-HJKMNP-TV-Z]+$", var.worker_pool_id))
+    error_message = "The worker pool ID must be a valid ULID (eg 01HCC6QZ932J7WDF4FTVM9QMEP)."
+  }
+}
+
+variable "base_name" {
+  type        = string
+  description = "Base name for resources. If unset, it defaults to `sp5ft-$${var.worker_pool_id}`."
+  nullable    = true
+  default     = null
 }
 
 variable "enable_monitoring" {
@@ -126,10 +137,6 @@ variable "instance_refresh" {
   description = "If this block is configured, start an Instance Refresh when this Auto Scaling Group is updated based on instance refresh configration."
   type        = any
   default     = {}
-}
-
-locals {
-  namespace = "sp5ft-${var.worker_pool_id}"
 }
 
 variable "enable_autoscaling" {

--- a/variables.tf
+++ b/variables.tf
@@ -113,7 +113,7 @@ variable "vpc_subnets" {
 
 variable "worker_pool_id" {
   type        = string
-  description = "ID of the the worker pool. It is used for the naming convention of the resources."
+  description = "ID (ULID) of the the worker pool."
   validation {
     condition     = can(regex("^[0-9A-HJKMNP-TV-Z]+$", var.worker_pool_id))
     error_message = "The worker pool ID must be a valid ULID (eg 01HCC6QZ932J7WDF4FTVM9QMEP)."


### PR DESCRIPTION
`var.worker_pool_id` has historically been effectively a free text field where users can enter any string usable as a worker pool identifier. For example, the pool's _name_ (rather than its ID).

With the module's new support for an autoscaler, this doesn't work. The autoscaler requires the pool's _ID_.

Make three changes:
0. Rename `local.namespace` to `local.base_name`. This is a less
   ambiguous term.
1. Add variable validation for `var.worker_pool_id` to ensure a real ID (ULID) is provided.
2. Add `var.base_name` which can optionally override the default local.base_name logic.

## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
