### PR TITLE
Make Lambda function instruction set architecture variable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.1.0
+module_version: 2.2.0
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.1.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.2.0"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"
@@ -108,6 +108,7 @@ $ make docs
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_tags"></a> [additional\_tags](#input\_additional\_tags) | Additional tags to set on the resources | `map(string)` | `{}` | no |
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | ID of the Spacelift AMI. If left empty, the latest Spacelift AMI will be used. | `string` | `""` | no |
+| <a name="input_autoscaler_architecture"></a> [autoscaler\_architecture](#input\_autoscaler\_architecture) | Instruction set architecture of the autoscaler to use | `string` | `"amd64"` | no |
 | <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"v0.2.0"` | no |
 | <a name="input_base_name"></a> [base\_name](#input\_base\_name) | Base name for resources. If unset, it defaults to `sp5ft-${var.worker_pool_id}`. | `string` | `null` | no |
 | <a name="input_configuration"></a> [configuration](#input\_configuration) | User configuration. This allows you to decide how you want to pass your token<br>  and private key to the environment - be that directly, or using SSM Parameter<br>  Store, Vault etc. Ultimately, here you need to export SPACELIFT\_TOKEN and<br>  SPACELIFT\_POOL\_PRIVATE\_KEY to the environment. | `string` | n/a | yes |

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -12,7 +12,7 @@ resource "aws_ssm_parameter" "spacelift_api_key_secret" {
 resource "null_resource" "download" {
   count = var.enable_autoscaling ? 1 : 0
   provisioner "local-exec" {
-    command = "${path.module}/download.sh ${var.autoscaler_version}"
+    command = "${path.module}/download.sh ${var.autoscaler_version} ${var.autoscaler_architecture}"
   }
 }
 
@@ -32,6 +32,7 @@ resource "aws_lambda_function" "autoscaler" {
   role             = aws_iam_role.autoscaler[count.index].arn
   handler          = "bootstrap"
   runtime          = "provided.al2"
+  architectures    = [var.autoscaler_architecture == "amd64" ? "x86_64" : var.autoscaler_architecture]
 
   environment {
     variables = {

--- a/download.sh
+++ b/download.sh
@@ -3,8 +3,9 @@ set -ex
 
 # Download the data.
 code_version=$1
+code_architecture=$2
 
-curl -L -o lambda.zip https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_amd64.zip
+curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
 
 mkdir -p lambda
 cd lambda

--- a/variables.tf
+++ b/variables.tf
@@ -151,6 +151,12 @@ variable "autoscaler_version" {
   default     = "v0.2.0"
 }
 
+variable "autoscaler_architecture" {
+  type        = string
+  description = "Instruction set architecture of the autoscaler to use"
+  default     = "amd64"
+}
+
 variable "spacelift_api_key_id" {
   type        = string
   description = "ID of the Spacelift API key to use"


### PR DESCRIPTION
## Description of the change

> [ec2-workerpool-scheduler](https://github.com/spacelift-io/ec2-workerpool-autoscaler) releases an amd64 and arm64 version.
> By adding a variable to this module, users are given the choice which one they'd like to use.
> amd64 was chosen as the default as this was previously the case.

## Type of change

- [X] New feature (non-breaking change that adds functionality);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
