### PR TITLE
fix: Lambda download during worker pool recreation, remove temp file

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -6,6 +6,7 @@ code_version=$1
 
 curl -L -o lambda.zip https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_amd64.zip
 
-mkdir lambda
+mkdir -p lambda
 cd lambda
-unzip ../lambda.zip
+unzip -o ../lambda.zip
+rm ../lambda.zip


### PR DESCRIPTION
## Description of the change


* Fix `mkdir` error: "cannot create directory ‘lambda’: File exists"
* Fix `unzip` interactive prompt/error: replace LICENSE? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
* Remove temporary zip file

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
