### PR TITLE
use different download folder name for lambda function

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -12,14 +12,14 @@ resource "aws_ssm_parameter" "spacelift_api_key_secret" {
 resource "null_resource" "download" {
   count = var.enable_autoscaling ? 1 : 0
   provisioner "local-exec" {
-    command = "${path.module}/download.sh ${var.autoscaler_version} ${var.autoscaler_architecture}"
+    command = "${path.module}/download.sh ${var.autoscaler_version} ${var.autoscaler_architecture} ${var.worker_pool_id}"
   }
 }
 
 data "archive_file" "binary" {
   count       = var.enable_autoscaling ? 1 : 0
   type        = "zip"
-  source_file = "lambda/bootstrap"
+  source_file = "${var.worker_pool_id}/bootstrap"
   output_path = "ec2-workerpool-autoscaler_${var.autoscaler_version}.zip"
   depends_on  = [null_resource.download]
 }

--- a/download.sh
+++ b/download.sh
@@ -4,10 +4,11 @@ set -ex
 # Download the data.
 code_version=$1
 code_architecture=$2
+local_folder=$3
 
 curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
 
-mkdir -p lambda
-cd lambda
+mkdir -p ${local_folder}
+cd ${local_folder}
 unzip -o ../lambda.zip
 rm ../lambda.zip


### PR DESCRIPTION
We encountered the problem, when the download.sh script is running "in parallel" there is an raise condition:

```shell
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): + curl -L -o lambda.zip https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/v0.2.0/ec2-workerpool-autoscaler_linux_amd64.zip
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):                                  Dload  Upload   Total   Spent    Left  Speed
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): 100  9.7M  100  9.7M    0     0  15.5M      0 --:--:-- --:--:-- --:--:-- 39.7M
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): 100  9.7M  100  9.7M    0     0  14.4M      0 --:--:-- --:--:-- --:--:-- 34.3M
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): + mkdir -p lambda
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): + cd lambda
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): + unzip -o ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): Archive:  ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): + mkdir -p lambda
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): + cd lambda
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): + unzip -o ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): Archive:  ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   inflating: LICENSE
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   inflating: README.md
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec):   inflating: bootstrap
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0] (local-exec): + rm ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0]: Creation complete after 1s [id=8647914972254941746]
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.data.archive_file.binary[0]: Reading...
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: LICENSE
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: README.md
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: bootstrap
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): + rm ../lambda.zip
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): rm: can't remove '../lambda.zip': No such file or directory
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.data.archive_file.binary[0]: Read complete after 1s [id=1d7cd3fb601080410c7eb30c1fad76aead505189]
╷
│ Error: local-exec provisioner error
│ 
│   with module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0],
│   on .terraform/modules/worker_pools.spacelift_worker_pool.workerpool/autoscaler.tf line 18, in resource "null_resource" "download":
│   18:   provisioner "local-exec" {
│ 
│ Error running command
│ '.terraform/modules/worker_pools.spacelift_worker_pool.workerpool/download.sh
│ v0.2.0': exit status 1. Output: + code_version=v0.2.0
│ + curl -L -o lambda.zip
│ https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/v0.2.0/ec2-workerpool-autoscaler_linux_amd64.zip
│   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
│                                  Dload  Upload   Total   Spent    Left  Speed
│ 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
│ 0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
│ 0
│ 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
│ 0
100  9.7M  100  9.7M    0     0  14.4M      0 --:--:-- --:--:-- --:--:--
│ 34.3M
│ + mkdir -p lambda
│ + cd lambda
│ + unzip -o ../lambda.zip
│ Archive:  ../lambda.zip
│   inflating: LICENSE
│   inflating: README.md
│   inflating: bootstrap
│ + rm ../lambda.zip
│ rm: can't remove '../lambda.zip': No such file or directory
```

Instead of using a static download folder named "lambda" using the var.worker_pool_id could fix the problem, what do you think?