### PR TITLE
Reset errexit flag in cloudinit script

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.3.1
+module_version: 2.3.2
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/asg.tf
+++ b/asg.tf
@@ -67,6 +67,8 @@ echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
 /usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
 )}
 
+# Reset the errexit option so if for some reason the `spacelift` binary steops, the poweroff should be run.
+set +e
 spacelift
 echo "Powering off in ${var.poweroff_delay} seconds" >> /var/log/spacelift/error.log
 sleep ${var.poweroff_delay}


### PR DESCRIPTION
## Description of the change

There has been an extremely rare case where the `spacelift` binary was no longer running, causing the cloud-init service to finish and the poweroff wasn't run because we have `set -e` at the top of the bash script.

This PR resets the errexit flag towards the end to ensure that the `poweroff` should still run.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
