### PR TITLE
fix: `autoscaler_version` can't be null

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.3.4
+module_version: 2.3.5
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.3.4"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.3.5"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"

--- a/variables.tf
+++ b/variables.tf
@@ -146,9 +146,10 @@ variable "enable_autoscaling" {
 }
 
 variable "autoscaler_version" {
-  type        = string
   description = "Version of the autoscaler to deploy"
+  type        = string
   default     = "v0.3.0"
+  nullable    = false
 }
 
 variable "autoscaler_architecture" {


### PR DESCRIPTION
## Description of the change

Currently, if you specify `autoscaler_version = null` you get 

```tf
│   on .terraform/modules/worker_pool/autoscaler.tf line 27, in data "archive_file" "binary":
│   27:   output_path = "ec2-workerpool-autoscaler_${var.autoscaler_version}.zip"
│     ├────────────────
│     │ var.autoscaler_version is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
```

during plan time.

We can move the error to init time and make it more meaningful:

```tf
╷
│ Error: Invalid default value for variable
│ 
│   on variables.tf line 68, in variable "autoscaler_version":
│   68:   default     = null
│ 
│ A null default value is not valid when nullable=false.
```


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
