### PR TITLE
Supports setting tag_specifications on the launch template

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.4.0
+module_version: 2.5.0
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ $ make docs
 | <a name="input_spacelift_api_key_endpoint"></a> [spacelift\_api\_key\_endpoint](#input\_spacelift\_api\_key\_endpoint) | Full URL of the Spacelift API endpoint to use, eg. https://demo.app.spacelift.io | `string` | `null` | no |
 | <a name="input_spacelift_api_key_id"></a> [spacelift\_api\_key\_id](#input\_spacelift\_api\_key\_id) | ID of the Spacelift API key to use | `string` | `null` | no |
 | <a name="input_spacelift_api_key_secret"></a> [spacelift\_api\_key\_secret](#input\_spacelift\_api\_key\_secret) | Secret corresponding to the Spacelift API key to use | `string` | `null` | no |
+| <a name="input_tag_specifications"></a> [tag\_specifications](#input\_tag\_specifications) | Tag specifications to set on the launch template, which will apply to the instances at launch | <pre>list(object({<br>    resource_type = string<br>    tags          = optional(map(string), {})<br>  }))</pre> | `[]` | no |
 | <a name="input_volume_encryption"></a> [volume\_encryption](#input\_volume\_encryption) | Whether to encrypt the EBS volume | `bool` | `false` | no |
 | <a name="input_volume_encryption_kms_key_id"></a> [volume\_encryption\_kms\_key\_id](#input\_volume\_encryption\_kms\_key\_id) | KMS key ID to use for encrypting the EBS volume | `string` | `null` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | Size of instance EBS volume | `number` | `40` | no |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.4.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.5.0"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"

--- a/asg.tf
+++ b/asg.tf
@@ -140,6 +140,8 @@ module "asg" {
     ])
   )
 
+  tag_specifications = var.tag_specifications
+
   tags = merge(var.additional_tags,
     {
       "WorkerPoolID" : var.worker_pool_id

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -44,4 +44,25 @@ module "this" {
   spacelift_api_key_secret   = var.spacelift_api_key_secret
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "volume"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "network-interface"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    }
+  ]
 }

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -67,4 +67,25 @@ module "this" {
   spacelift_api_key_secret   = var.spacelift_api_key_secret
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "volume"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "network-interface"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    }
+  ]
 }

--- a/examples/autoscaler-s3-package/main.tf
+++ b/examples/autoscaler-s3-package/main.tf
@@ -35,4 +35,25 @@ module "this" {
     bucket = aws_s3_bucket.autoscaler_binary.id
     key    = aws_s3_object.autoscaler_binary.id
   }
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "volume"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "network-interface"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    }
+  ]
 }

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -69,4 +69,25 @@ module "this" {
   spacelift_api_key_secret   = var.spacelift_api_key_secret
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "volume"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    },
+    {
+      resource_type = "network-interface"
+      tags = {
+        Name = "sp5ft-${var.worker_pool_id}"
+      }
+    }
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,15 @@ variable "additional_tags" {
   default     = {}
 }
 
+variable "tag_specifications" {
+  description = "Tag specifications to set on the launch template, which will apply to the instances at launch"
+  type = list(object({
+    resource_type = string
+    tags          = optional(map(string), {})
+  }))
+  default = []
+}
+
 variable "volume_encryption" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Description of the change

Supports setting tag_specifcations on the launch template. This gives users the ability to address their own organizational tagging policy requirements on EC2 instances, volumes, and network interfaces.

Fixes #87

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
