### PR TITLE
 fix: Avoid uncontrolled termination of instances as result of ASG rebalancing

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.6.0
+module_version: 2.6.1
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.6.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.6.1"
 
   configuration = <<-EOT
     export SPACELIFT_TOKEN="${var.worker_pool_config}"

--- a/asg.tf
+++ b/asg.tf
@@ -133,7 +133,7 @@ module "asg" {
 
   suspended_processes = [
     # Prevents the ASG from terminating instances for rebalancing between AZs, 
-    #  which triggered right after termination of instances by lambda
+    # which triggered right after termination of instances by lambda
     "AZRebalance"
   ]
 

--- a/asg.tf
+++ b/asg.tf
@@ -131,6 +131,12 @@ module "asg" {
     http_put_response_hop_limit = var.disable_container_credentials ? 1 : 2
   }
 
+  suspended_processes = [
+    # Prevents the ASG from terminating instances for rebalancing between AZs, 
+    #  which triggered right after termination of instances by lambda
+    "AZRebalance"
+  ]
+
   # User data
   user_data = base64encode(
     join("\n", [


### PR DESCRIPTION
## Description of the change

Deal with "additional termination" caused by ASG rebalancing, right after lambda terminate instances in ASG.

>At 2024-08-27T09:52:34Z instances were launched to balance instances in zones us-east-1a us-east-1b us-east-1c with other zones resulting in more than desired number of instances in the group. At 2024-08-27T09:52:57Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 60 to 58. At 2024-08-27T09:52:58Z instance i-0030c7e66ed334788 was selected for termination. At 2024-08-27T09:52:58Z instance i-004c326654c417f9c was selected for termination.



![image](https://github.com/user-attachments/assets/a3dcd688-4773-4d67-a2a2-e39a88f2f275)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
