### PR TITLE
fix the deprication warning for inline_policy on aws_iam_role resource

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.6.2
+module_version: 2.6.3
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ $ make docs
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.allow_cloudwatch_to_call_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |

--- a/iam.tf
+++ b/iam.tf
@@ -122,11 +122,13 @@ resource "aws_iam_role" "autoscaler" {
     ]
   })
 
-  inline_policy {
-    name   = "ec2-autoscaler-${var.worker_pool_id}"
-    policy = data.aws_iam_policy_document.autoscaler[count.index].json
-  }
-
   depends_on = [module.asg]
   tags       = var.additional_tags
+}
+
+resource "aws_iam_role_policy" "autoscaler" {
+  count  = var.enable_autoscaling ? 1 : 0
+  name   = "ec2-autoscaler-${var.worker_pool_id}"
+  role   = aws_iam_role.autoscaler[0].name
+  policy = data.aws_iam_policy_document.autoscaler[count.index].json
 }


### PR DESCRIPTION
## Description of the change

> This gives a deprecation notice if we run it with aws provider > 5 version. This PR fixes that issue. 
<img width="896" alt="image" src="https://github.com/user-attachments/assets/09e0f3ea-963e-453c-9c19-7651aaa990f9">

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue);
- [X] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
