### PR TITLE
Update the default Autoscaler version to 1.0.1

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.6.3
+module_version: 2.7.0
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "enable_autoscaling" {
 variable "autoscaler_version" {
   description = "Version of the autoscaler to deploy"
   type        = string
-  default     = "v0.3.0"
+  default     = "v1.0.1"
   nullable    = false
 }
 


### PR DESCRIPTION
## Description of the change

Version [0.3.0](https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/tag/v0.3.0) is no longer the latest version of the autoscaler:

- https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/tag/v1.0.1
- https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/tag/v1.0.0

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);
- [x] Maintenance

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
