### PR TITLE
fix: adding support for opt-in regions and arm architecture

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.6.4
+module_version: 2.6.5
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/ami.tf
+++ b/ami.tf
@@ -1,7 +1,13 @@
-data "aws_ami" "this" {
-  most_recent = true
-  name_regex  = "^spacelift-\\d{10}-x86_64$"
-  owners      = ["643313122712"]
+# get info about selected instance type
+data "aws_ec2_instance_type" "spacelift" {
+  instance_type = var.ec2_instance_type
+}
+
+# get list of spacelift AMI ids starting with the newest
+data "aws_ami_ids" "spacelift" {
+  sort_ascending = false
+  name_regex     = "^spacelift-\\d{10}-(arm64|x86_64)$"
+  owners         = ["643313122712"]
 
   filter {
     name   = "root-device-type"
@@ -14,7 +20,16 @@ data "aws_ami" "this" {
   }
 
   filter {
-    name   = "architecture"
-    values = ["x86_64"]
+    name = "architecture"
+    # get ami architecture based on selected instance type (arm64 or x86_64).
+    values = [for arch in data.aws_ec2_instance_type.spacelift.supported_architectures : arch if can(regex("(arm64|x86_64)$", arch))]
+  }
+
+  lifecycle {
+    # Check if Spacelift AMI exists in current region. Spacelift AMIs are not replicated for all regions.
+    postcondition {
+      condition     = coalesce(var.ami_id, try(self.ids[0], "ami_not_found")) != "ami_not_found"
+      error_message = "No Spacelift AMI found in current region '${data.aws_region.this.name}'. Use 'var.ami_id' instead to provide an existing Spacelift AMI."
+    }
   }
 }

--- a/asg.tf
+++ b/asg.tf
@@ -83,11 +83,12 @@ module "asg" {
   name = local.base_name
 
   iam_instance_profile_arn = aws_iam_instance_profile.this.arn
-  image_id                 = var.ami_id != "" ? var.ami_id : data.aws_ami.this.id
-  instance_type            = var.ec2_instance_type
-  security_groups          = var.security_groups
-  enable_monitoring        = var.enable_monitoring
-  instance_refresh         = var.instance_refresh
+  # if 'var.ami_id' is empty, get AMI from data source. data source lifecycle postcondition fails if no ami exists.
+  image_id          = coalesce(var.ami_id, try(data.aws_ami_ids.spacelift.ids[0], "ami_not_found"))
+  instance_type     = var.ec2_instance_type
+  security_groups   = var.security_groups
+  enable_monitoring = var.enable_monitoring
+  instance_refresh  = var.instance_refresh
 
   block_device_mappings = [
     {


### PR DESCRIPTION
## Description of the change

This module cannot currently be used in opt-in regions (e.g. Zurich eu-central-2) where the Spacelift AMIs are not replicated. 
Also when using a custom AMI via `var.ami_id` the module fails as the data source `data.aws_ami.this` always fails if there is no Spacelift AMI in the Spacelift AWS account (643313122712). Using `data.aws_ami_ids.spacelift` avoids this problem as the data source returns an empty list if the AMI does not exist. A lifecycle postcondition checks that an AMI was provided either with `var.ami_id` or by the data source.

When choosing an arm based instance type via `var.ec2_instance_type` the data source `data.aws_ami.this` will return a x86_64 AMI because it's hardcoded into the name_regex and filter. By adding the `data.aws_ec2_instance_type.spacelift` data source we can dynamically get the correct architecture for the Spacelift AMI. This allows to use the latest arm based Spacelift AMIs by default.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
