### PR TITLE
FEATURE Add instance market options support for the ASG

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.6.4
+module_version: 2.6.5
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/asg.tf
+++ b/asg.tf
@@ -88,6 +88,7 @@ module "asg" {
   security_groups          = var.security_groups
   enable_monitoring        = var.enable_monitoring
   instance_refresh         = var.instance_refresh
+  instance_market_options  = var.instance_market_options
 
   block_device_mappings = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -226,3 +226,8 @@ variable "autoscaler_s3_package" {
   default     = null
 }
 
+variable "instance_market_options" {
+  description = "The market (purchasing) option for the instance"
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## Description of the change

This change adds a new feature to be able to request  instance_market_options to the ASG creation. Currently this TF module uses a 3rd party module which supports the option to create spot instances. Spot instances are a perfect use case for runners which sit idle a lot of the time. With the support of the new variable, you can now request SPOT EC2s by adding the following code to the module.

This change allows the variable to be passed from module to module. We use spot instances all the time and have had to manually update the template. This change will add spot instance support to this module. I have tested this on my fork

`instance_market_options = {
    market_type = "spot"
`}

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ X] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [X ] All necessary variables have been defined, with defaults if applicable;
- [ X] The code is formatted properly;

### Code review

- [ X] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
