### PR TITLE
Revert "Merge pull request #108 from jubranNassar/move-autoscaling-logic"

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,16 +1,13 @@
 version: 1
-module_version: 2.8.0
+module_version: 2.9.0
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64
     environment:
-      AWS_DEFAULT_REGION: "eu-west-1"
       TF_VAR_spacelift_api_key_id: "EXAMPLE0VOYU49U485BMZZVAWXU59VOW2"
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8EEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
 
   - name: ARM64-based workerpool
     project_root: examples/arm64
@@ -19,8 +16,6 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8AEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
 
   - name: Custom IAM Role
     project_root: examples/custom-iam-role
@@ -29,8 +24,6 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8CEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
 
   - name: S3-hosted autoscaler
     project_root: examples/autoscaler-s3-package
@@ -40,5 +33,3 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8CEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"

--- a/README.md
+++ b/README.md
@@ -74,23 +74,35 @@ $ make docs
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.55.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_asg"></a> [asg](#module\_asg) | terraform-aws-modules/autoscaling/aws | ~> 8.0 |
-| <a name="module_autoscaler"></a> [autoscaler](#module\_autoscaler) | github.com/spacelift-io/ec2-workerpool-autoscaler//iac | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.scheduling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.scheduling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.allow_cloudwatch_to_call_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_ssm_parameter.spacelift_api_key_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [null_resource.download](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [archive_file.binary](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -101,8 +113,7 @@ $ make docs
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | ID of the Spacelift AMI. If left empty, the latest Spacelift AMI will be used. | `string` | `""` | no |
 | <a name="input_autoscaler_architecture"></a> [autoscaler\_architecture](#input\_autoscaler\_architecture) | Instruction set architecture of the autoscaler to use | `string` | `"amd64"` | no |
 | <a name="input_autoscaler_s3_package"></a> [autoscaler\_s3\_package](#input\_autoscaler\_s3\_package) | Configuration to retrieve autoscaler lambda package from s3 bucket | <pre>object({<br>    bucket         = string<br>    key            = string<br>    object_version = optional(string)<br>  })</pre> | `null` | no |
-| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"latest"` | no |
-| <a name="input_autoscaling_group_arn"></a> [autoscaling\_group\_arn](#input\_autoscaling\_group\_arn) | autoscaling group ARN. Required for autoscaler | `string` | n/a | yes |
+| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"v0.3.0"` | no |
 | <a name="input_autoscaling_max_create"></a> [autoscaling\_max\_create](#input\_autoscaling\_max\_create) | The maximum number of instances the utility is allowed to create in a single run | `number` | `1` | no |
 | <a name="input_autoscaling_max_terminate"></a> [autoscaling\_max\_terminate](#input\_autoscaling\_max\_terminate) | The maximum number of instances the utility is allowed to terminate in a single run | `number` | `1` | no |
 | <a name="input_autoscaling_timeout"></a> [autoscaling\_timeout](#input\_autoscaling\_timeout) | Timeout (in seconds) for a single autoscaling run. The more instances you have, the higher this should be. | `number` | `30` | no |
@@ -120,7 +131,6 @@ $ make docs
 | <a name="input_max_size"></a> [max\_size](#input\_max\_size) | Maximum number of workers to spin up | `number` | `10` | no |
 | <a name="input_min_size"></a> [min\_size](#input\_min\_size) | Minimum numbers of workers to spin up | `number` | `0` | no |
 | <a name="input_poweroff_delay"></a> [poweroff\_delay](#input\_poweroff\_delay) | Number of seconds to wait before powering the EC2 instance off after the Spacelift launcher stopped | `number` | `15` | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS region to deploy to | `string` | n/a | yes |
 | <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | Autoscaler scheduling expression | `string` | `"rate(1 minute)"` | no |
 | <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | List of security groups to use | `list(string)` | n/a | yes |
 | <a name="input_spacelift_api_key_endpoint"></a> [spacelift\_api\_key\_endpoint](#input\_spacelift\_api\_key\_endpoint) | Full URL of the Spacelift API endpoint to use, eg. https://demo.app.spacelift.io | `string` | `null` | no |

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -1,64 +1,97 @@
-module "autoscaler" {
-  source = "github.com/spacelift-io/ec2-workerpool-autoscaler//iac"
-
-  for_each = var.enable_autoscaling ? toset(["ENABLED"]) : toset([])
-
-  autoscaling_group_arn      = var.autoscaling_group_arn
-  autoscaler_version         = var.autoscaler_version
-  spacelift_api_key_id       = var.spacelift_api_key_id
-  spacelift_api_key_secret   = var.spacelift_api_key_secret
-  spacelift_api_key_endpoint = var.spacelift_api_key_endpoint
-  worker_pool_id             = var.worker_pool_id
-  autoscaler_architecture    = var.autoscaler_architecture
-  autoscaling_timeout        = var.autoscaling_timeout
-  autoscaling_max_create     = var.autoscaling_max_create
-  autoscaling_max_terminate  = var.autoscaling_max_terminate
-  schedule_expression        = var.schedule_expression
-  base_name                  = var.base_name
-  region                     = var.region
-  autoscaler_s3_package      = var.autoscaler_s3_package
-  subnet_ids                 = var.vpc_subnets
-  security_group_ids         = var.security_groups
-
-  depends_on = [module.asg]
+locals {
+  function_name  = "${local.base_name}-ec2-autoscaler"
+  use_s3_package = var.autoscaler_s3_package != null
 }
 
-moved {
-  from = aws_ssm_parameter.spacelift_api_key_secret[0]
-  to   = module.autoscaler["ENABLED"].aws_ssm_parameter.spacelift_api_key_secret
+resource "aws_ssm_parameter" "spacelift_api_key_secret" {
+  count = var.enable_autoscaling ? 1 : 0
+  name  = "/${local.function_name}/spacelift-api-secret-${var.worker_pool_id}"
+  type  = "SecureString"
+  value = var.spacelift_api_key_secret
+  tags  = var.additional_tags
 }
 
-moved {
-  from = null_resource.download[0]
-  to   = module.autoscaler["ENABLED"].null_resource.download
+resource "null_resource" "download" {
+  count = var.enable_autoscaling && !local.use_s3_package ? 1 : 0
+  triggers = {
+    # Always re-download the archive file
+    now = timestamp()
+  }
+  provisioner "local-exec" {
+    command = "${path.module}/download.sh ${var.autoscaler_version} ${var.autoscaler_architecture}"
+  }
 }
 
-moved {
-  from = aws_lambda_function.autoscaler[0]
-  to   = module.autoscaler["ENABLED"].aws_lambda_function.autoscaler
+data "archive_file" "binary" {
+  count       = var.enable_autoscaling && !local.use_s3_package ? 1 : 0
+  type        = "zip"
+  source_file = "lambda/bootstrap"
+  output_path = "ec2-workerpool-autoscaler_${var.autoscaler_version}.zip"
+  depends_on  = [null_resource.download]
 }
 
-moved {
-  from = aws_cloudwatch_event_rule.scheduling[0]
-  to   = module.autoscaler["ENABLED"].aws_cloudwatch_event_rule.scheduling
+resource "aws_lambda_function" "autoscaler" {
+  count = var.enable_autoscaling ? 1 : 0
+
+  filename         = !local.use_s3_package ? data.archive_file.binary[count.index].output_path : null
+  source_code_hash = !local.use_s3_package ? data.archive_file.binary[count.index].output_base64sha256 : null
+
+  s3_bucket         = local.use_s3_package ? var.autoscaler_s3_package.bucket : null
+  s3_key            = local.use_s3_package ? var.autoscaler_s3_package.key : null
+  s3_object_version = local.use_s3_package ? var.autoscaler_s3_package.object_version : null
+
+  function_name = local.function_name
+  role          = aws_iam_role.autoscaler[count.index].arn
+  handler       = "bootstrap"
+  runtime       = "provided.al2"
+  architectures = [var.autoscaler_architecture == "amd64" ? "x86_64" : var.autoscaler_architecture]
+  timeout       = var.autoscaling_timeout
+
+  environment {
+    variables = {
+      AUTOSCALING_GROUP_ARN         = module.asg.autoscaling_group_arn
+      AUTOSCALING_REGION            = data.aws_region.this.name
+      SPACELIFT_API_KEY_ID          = var.spacelift_api_key_id
+      SPACELIFT_API_KEY_SECRET_NAME = aws_ssm_parameter.spacelift_api_key_secret[count.index].name
+      SPACELIFT_API_KEY_ENDPOINT    = var.spacelift_api_key_endpoint
+      SPACELIFT_WORKER_POOL_ID      = var.worker_pool_id
+      AUTOSCALING_MAX_CREATE        = var.autoscaling_max_create
+      AUTOSCALING_MAX_KILL          = var.autoscaling_max_terminate
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+  tags = var.additional_tags
 }
 
-moved {
-  from = aws_cloudwatch_event_target.scheduling[0]
-  to   = module.autoscaler["ENABLED"].aws_cloudwatch_event_target.scheduling
+resource "aws_cloudwatch_event_rule" "scheduling" {
+  count               = var.enable_autoscaling ? 1 : 0
+  name                = local.function_name
+  description         = "Spacelift autoscaler scheduling for worker pool ${var.worker_pool_id}"
+  schedule_expression = var.schedule_expression
+  tags                = var.additional_tags
 }
 
-moved {
-  from = aws_lambda_permission.allow_cloudwatch_to_call_lambda[0]
-  to   = module.autoscaler["ENABLED"].aws_lambda_permission.allow_cloudwatch_to_call_lambda
+resource "aws_cloudwatch_event_target" "scheduling" {
+  count = var.enable_autoscaling ? 1 : 0
+  rule  = aws_cloudwatch_event_rule.scheduling[count.index].name
+  arn   = aws_lambda_function.autoscaler[count.index].arn
 }
 
-moved {
-  from = aws_cloudwatch_log_group.log_group[0]
-  to   = module.autoscaler["ENABLED"].aws_cloudwatch_log_group.log_group
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
+  count         = var.enable_autoscaling ? 1 : 0
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.autoscaler[count.index].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.scheduling[count.index].arn
 }
 
-moved {
-  from = aws_iam_role.autoscaler[0]
-  to   = module.autoscaler["ENABLED"].aws_iam_role.autoscaler
+resource "aws_cloudwatch_log_group" "log_group" {
+  count             = var.enable_autoscaling ? 1 : 0
+  name              = "/aws/lambda/${local.function_name}"
+  retention_in_days = 7
+  tags              = var.additional_tags
 }

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -ex
+
+# Download the data.
+code_version=$1
+code_architecture=$2
+
+curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
+
+mkdir -p lambda
+cd lambda
+unzip -o ../lambda.zip
+rm ../lambda.zip

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -38,8 +38,6 @@ module "this" {
     export SPACELIFT_TOKEN="<token-here>"
     export SPACELIFT_POOL_PRIVATE_KEY="<private-key-here>"
   EOT
-  autoscaling_group_arn      = var.autoscaling_group_arn
-  region                     = var.region
   security_groups            = [data.aws_security_group.this.id]
   spacelift_api_key_endpoint = var.spacelift_api_key_endpoint
   spacelift_api_key_id       = var.spacelift_api_key_id

--- a/examples/amd64/variables.tf
+++ b/examples/amd64/variables.tf
@@ -18,13 +18,3 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
-
-variable "autoscaling_group_arn" {
-  type        = string
-  description = "autoscaling group ARN. Required for autoscaler"
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to deploy to"
-}

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -59,8 +59,6 @@ module "this" {
     export SPACELIFT_TOKEN="<token-here>"
     export SPACELIFT_POOL_PRIVATE_KEY="<private-key-here>"
   EOT
-  autoscaling_group_arn      = var.autoscaling_group_arn
-  region                     = var.region
   ami_id                     = data.aws_ami.this.id
   ec2_instance_type          = "t4g.micro"
   security_groups            = [data.aws_security_group.this.id]

--- a/examples/arm64/variables.tf
+++ b/examples/arm64/variables.tf
@@ -18,13 +18,3 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
-
-variable "autoscaling_group_arn" {
-  type        = string
-  description = "autoscaling group ARN. Required for autoscaler"
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to deploy to"
-}

--- a/examples/autoscaler-s3-package/main.tf
+++ b/examples/autoscaler-s3-package/main.tf
@@ -23,8 +23,6 @@ module "this" {
     export SPACELIFT_TOKEN="<token-here>"
     export SPACELIFT_POOL_PRIVATE_KEY="<private-key-here>"
   EOT
-  autoscaling_group_arn      = var.autoscaling_group_arn
-  region                     = var.region
   security_groups            = [data.aws_security_group.this.id]
   spacelift_api_key_endpoint = var.spacelift_api_key_endpoint
   spacelift_api_key_id       = var.spacelift_api_key_id

--- a/examples/autoscaler-s3-package/variables.tf
+++ b/examples/autoscaler-s3-package/variables.tf
@@ -31,13 +31,3 @@ variable "autoscaler_architecture" {
   description = "Instruction set architecture of the autoscaler to use"
   default     = "amd64"
 }
-
-variable "autoscaling_group_arn" {
-  type        = string
-  description = "autoscaling group ARN. Required for autoscaler"
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to deploy to"
-}

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -61,8 +61,6 @@ module "this" {
     export SPACELIFT_TOKEN="<token-here>"
     export SPACELIFT_POOL_PRIVATE_KEY="<private-key-here>"
   EOT
-  autoscaling_group_arn      = var.autoscaling_group_arn
-  region                     = var.region
   create_iam_role            = false
   custom_iam_role_name       = aws_iam_role.this.name
   security_groups            = [data.aws_security_group.this.id]

--- a/examples/custom-iam-role/variables.tf
+++ b/examples/custom-iam-role/variables.tf
@@ -18,13 +18,3 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
-
-variable "autoscaling_group_arn" {
-  type        = string
-  description = "autoscaling group ARN. Required for autoscaler"
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to deploy to"
-}

--- a/iam.tf
+++ b/iam.tf
@@ -50,3 +50,85 @@ resource "aws_iam_instance_profile" "this" {
   tags = var.additional_tags
 }
 
+data "aws_iam_policy_document" "autoscaler" {
+  count = var.enable_autoscaling ? 1 : 0
+  # Allow the Lambda to write CloudWatch Logs.
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["${aws_cloudwatch_log_group.log_group[count.index].arn}:*"]
+  }
+
+  # Allow the Lambda to put X-Ray traces.
+  statement {
+    effect = "Allow"
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow the Lambda to DescribeAutoScalingGroups, DetachInstances and SetDesiredCapacity
+  # on the AutoScalingGroup.
+  statement {
+    effect = "Allow"
+    actions = [
+      "autoscaling:DetachInstances",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DescribeAutoScalingGroups",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow the Lambda to DescribeInstances and TerminateInstances on the EC2 instances.
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstances",
+      "ec2:TerminateInstances",
+    ]
+
+    resources = ["*"]
+  }
+
+  # Allow the Lambda to read the secret from SSM Parameter Store.
+  statement {
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter"]
+    resources = [aws_ssm_parameter.spacelift_api_key_secret[count.index].arn]
+  }
+}
+
+resource "aws_iam_role" "autoscaler" {
+  count = var.enable_autoscaling ? 1 : 0
+  name  = local.function_name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "lambda.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      },
+    ]
+  })
+
+  depends_on = [module.asg]
+  tags       = var.additional_tags
+}
+
+resource "aws_iam_role_policy" "autoscaler" {
+  count  = var.enable_autoscaling ? 1 : 0
+  name   = "ec2-autoscaler-${var.worker_pool_id}"
+  role   = aws_iam_role.autoscaler[0].name
+  policy = data.aws_iam_policy_document.autoscaler[count.index].json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,11 +26,6 @@ variable "disable_container_credentials" {
   default     = true
 }
 
-variable "autoscaling_group_arn" {
-  type        = string
-  description = "autoscaling group ARN. Required for autoscaler"
-}
-
 variable "domain_name" {
   type        = string
   description = "Top-level domain name to use for pulling the launcher binary"
@@ -162,7 +157,7 @@ variable "enable_autoscaling" {
 variable "autoscaler_version" {
   description = "Version of the autoscaler to deploy"
   type        = string
-  default     = "latest"
+  default     = "v0.3.0"
   nullable    = false
 }
 
@@ -229,10 +224,5 @@ variable "autoscaler_s3_package" {
   })
   description = "Configuration to retrieve autoscaler lambda package from s3 bucket"
   default     = null
-}
-
-variable "region" {
-  type        = string
-  description = "AWS region to deploy to"
 }
 


### PR DESCRIPTION
This reverts commit fbb44d2a39d75ad2803553833ca9f639bbd753f2, reversing changes made to d6ead175668024308f2eecfc2952246fe7f084e9.

## Description of the change

The changes in #108 resulted in a module that did not actually deploy the same infrastructure as before. Currently there is no viable upgrade path from 1.6.4 to 1.7 or higher. If truly desired, that is a completely backwards incompatible change, not a minor version bump. See https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/108#issuecomment-2632359658.

Reverting the change is simply step 1 to making the module usable again. Ultimately, to achieve the same goal as #108, this module can provide a submodule for the lambda asg wrapper, and the lambda project can host it's own root module that invokes only the submodule instead of the entire project.

See also: https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/111

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
