### PR TITLE
feat: pull in latest autoscaler by default

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.9.0
+module_version: 2.9.1
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $ make docs
 | <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | ID of the Spacelift AMI. If left empty, the latest Spacelift AMI will be used. | `string` | `""` | no |
 | <a name="input_autoscaler_architecture"></a> [autoscaler\_architecture](#input\_autoscaler\_architecture) | Instruction set architecture of the autoscaler to use | `string` | `"amd64"` | no |
 | <a name="input_autoscaler_s3_package"></a> [autoscaler\_s3\_package](#input\_autoscaler\_s3\_package) | Configuration to retrieve autoscaler lambda package from s3 bucket | <pre>object({<br>    bucket         = string<br>    key            = string<br>    object_version = optional(string)<br>  })</pre> | `null` | no |
-| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"v0.3.0"` | no |
+| <a name="input_autoscaler_version"></a> [autoscaler\_version](#input\_autoscaler\_version) | Version of the autoscaler to deploy | `string` | `"latest"` | no |
 | <a name="input_autoscaling_max_create"></a> [autoscaling\_max\_create](#input\_autoscaling\_max\_create) | The maximum number of instances the utility is allowed to create in a single run | `number` | `1` | no |
 | <a name="input_autoscaling_max_terminate"></a> [autoscaling\_max\_terminate](#input\_autoscaling\_max\_terminate) | The maximum number of instances the utility is allowed to terminate in a single run | `number` | `1` | no |
 | <a name="input_autoscaling_timeout"></a> [autoscaling\_timeout](#input\_autoscaling\_timeout) | Timeout (in seconds) for a single autoscaling run. The more instances you have, the higher this should be. | `number` | `30` | no |

--- a/download.sh
+++ b/download.sh
@@ -3,9 +3,23 @@ set -ex
 
 # Download the data.
 code_version=$1
-code_architecture=$2
+export code_architecture=$2
 
-curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
+if [ "$code_version" != "latest" ]; then
+  code_version="tags/$code_version"
+fi
+
+release=$(curl -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/${code_version}" | jq -r --arg ZIP "ec2-workerpool-autoscaler_linux_$code_architecture.zip" '.assets[] | select(.name==$ZIP)')
+
+release_date=$(echo $release | jq -r '.created_at')
+download_url=$(echo $release | jq -r '.browser_download_url')
+
+echo "Downloading Details:"
+echo "  Release Name: $code_version"
+echo "  Release Date: $release_date"
+echo "  Download URL: $download_url"
+
+curl -L -o lambda.zip $download_url
 
 mkdir -p lambda
 cd lambda

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "enable_autoscaling" {
 variable "autoscaler_version" {
   description = "Version of the autoscaler to deploy"
   type        = string
-  default     = "v0.3.0"
+  default     = "latest"
   nullable    = false
 }
 


### PR DESCRIPTION
Pulls in the latest autoscaler by default, can still version pin if required.