### PR TITLE
feat: handle api rate limits and change the keeper on the download script

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -9,8 +9,7 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8EEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
+      TF_VAR_autocaler_version: "latest"
 
   - name: ARM64-based workerpool
     project_root: examples/arm64
@@ -19,8 +18,7 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8AEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
+      TF_VAR_autocaler_version: "v1.0.3"
 
   - name: Custom IAM Role
     project_root: examples/custom-iam-role
@@ -29,8 +27,7 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8CEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
+      TF_VAR_autocaler_version: "v1.0.3"
 
   - name: S3-hosted autoscaler
     project_root: examples/autoscaler-s3-package
@@ -40,5 +37,4 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLEf7anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
       TF_VAR_worker_pool_id: "01HBD5QZ932J8CEH5GTBM1QMAS"
-      TF_VAR_region: "eu-west-1"
-      TF_VAR_autoscaling_group_arn: "arn:aws:autoscaling:us-east-1:379163426062:autoScalingGroup:57850428-516b-4ffd-9ee5-ccb638077dba:autoScalingGroupName/sp5ft-01GSXBC5843YVQGESHRK33GTTZ-20230301230633970400000002"
+      TF_VAR_autocaler_version: "v1.0.3"

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.10.0
+module_version: 2.11.0
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -14,8 +14,8 @@ resource "aws_ssm_parameter" "spacelift_api_key_secret" {
 resource "null_resource" "download" {
   count = var.enable_autoscaling && !local.use_s3_package ? 1 : 0
   triggers = {
-    # Always re-download the archive file
-    now = timestamp()
+    # Always re-download the archive file if the version is set to "latest"
+    keeper = var.autoscaler_version == "latest" ? timestamp() : var.autoscaler_version
   }
   provisioner "local-exec" {
     command = "${path.module}/download.sh ${var.autoscaler_version} ${var.autoscaler_architecture}"

--- a/download.sh
+++ b/download.sh
@@ -6,20 +6,34 @@ code_version=$1
 export code_architecture=$2
 
 if [ "$code_version" != "latest" ]; then
-  code_version="tags/$code_version"
+  # If the code version is not latest, we dont need to hit the github api.
+  curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
+else
+  # Make a temporary file to store the headers in
+  tmpfile=$(mktemp /tmp/spacelift-request-headers.XXXXXX)
+  request=$(curl -D "$tmpfile" -X GET -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/latest")
+  ratelimit=$(cat "$tmpfile" | grep x-ratelimit-remaining | awk '{print $2}' | tr -d '\012\015')
+  rm "$tmpfile"
+  if [ $ratelimit = "0" ]; then
+      echo "Github API rate limit exceeded, cannot find latest version. Please try again later or version pin the module."
+      exit 1
+  else
+    echo "Github API rate limit remaining: '$ratelimit'"
+
+    # Use printf here because echo will evaluate new lines which breaks the json formatting for jq
+    release=$(printf '%s' "$request" | jq -r --arg ZIP "ec2-workerpool-autoscaler_linux_$code_architecture.zip" '.assets[] | select(.name==$ZIP)')
+
+    release_date=$(echo $release | jq -r '.created_at')
+    download_url=$(echo $release | jq -r '.browser_download_url')
+
+    echo "Downloading Details:"
+    echo "  Release Name: $code_version"
+    echo "  Release Date: $release_date"
+    echo "  Download URL: $download_url"
+
+    curl -L -o lambda.zip $download_url
+  fi
 fi
-
-release=$(curl -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/${code_version}" | jq -r --arg ZIP "ec2-workerpool-autoscaler_linux_$code_architecture.zip" '.assets[] | select(.name==$ZIP)')
-
-release_date=$(echo $release | jq -r '.created_at')
-download_url=$(echo $release | jq -r '.browser_download_url')
-
-echo "Downloading Details:"
-echo "  Release Name: $code_version"
-echo "  Release Date: $release_date"
-echo "  Download URL: $download_url"
-
-curl -L -o lambda.zip $download_url
 
 mkdir -p lambda
 cd lambda

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -45,6 +45,8 @@ module "this" {
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
 
+  autoscaler_version = var.autoscaler_version
+
   tag_specifications = [
     {
       resource_type = "instance"

--- a/examples/amd64/variables.tf
+++ b/examples/amd64/variables.tf
@@ -18,3 +18,8 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
+
+variable "autoscaler_version" {
+  type = string
+  default = "latest"
+}

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -68,6 +68,8 @@ module "this" {
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
 
+  autoscaler_version = var.autoscaler_version
+
   tag_specifications = [
     {
       resource_type = "instance"

--- a/examples/arm64/variables.tf
+++ b/examples/arm64/variables.tf
@@ -18,3 +18,8 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
+
+variable "autoscaler_version" {
+  type = string
+  default = "latest"
+}

--- a/examples/autoscaler-s3-package/main.tf
+++ b/examples/autoscaler-s3-package/main.tf
@@ -30,6 +30,8 @@ module "this" {
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
 
+  autoscaler_version = var.autoscaler_version
+
   enable_autoscaling = true
   autoscaler_s3_package = {
     bucket = aws_s3_bucket.autoscaler_binary.id

--- a/examples/autoscaler-s3-package/variables.tf
+++ b/examples/autoscaler-s3-package/variables.tf
@@ -22,7 +22,7 @@ variable "worker_pool_id" {
 variable "autoscaler_version" {
   description = "Version of the autoscaler to deploy"
   type        = string
-  default     = "v0.3.0"
+  default     = "latest"
   nullable    = false
 }
 

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -70,6 +70,8 @@ module "this" {
   vpc_subnets                = data.aws_subnets.this.ids
   worker_pool_id             = var.worker_pool_id
 
+  autoscaler_version = var.autoscaler_version
+
   tag_specifications = [
     {
       resource_type = "instance"

--- a/examples/custom-iam-role/variables.tf
+++ b/examples/custom-iam-role/variables.tf
@@ -18,3 +18,8 @@ variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."
 }
+
+variable "autoscaler_version" {
+  type = string
+  default = "latest"
+}


### PR DESCRIPTION
This PR just changes it so we only use the github api if the version is `latest`. This will prevent users from running into github api rate limits. It will also check the rate limit and error with the specific message that the api is being rate limited if that is the issue when the version is indeed `latest`.