### PR TITLE
feat: support github_token variable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.11.0
+module_version: 2.11.1
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/download.sh
+++ b/download.sh
@@ -11,7 +11,12 @@ if [ "$code_version" != "latest" ]; then
 else
   # Make a temporary file to store the headers in
   tmpfile=$(mktemp /tmp/spacelift-request-headers.XXXXXX)
-  request=$(curl -D "$tmpfile" -X GET -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/latest")
+  # If GITHUB_TOKEN is set, we can benefit from its higher rate limit
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    request=$(curl -D "$tmpfile" -X GET --header "Authorization: Bearer ${GITHUB_TOKEN}" -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/latest")
+  else
+    request=$(curl -D "$tmpfile" -X GET -sS "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/latest")
+  fi
   ratelimit=$(cat "$tmpfile" | grep x-ratelimit-remaining | awk '{print $2}' | tr -d '\012\015')
   rm "$tmpfile"
   if [ $ratelimit = "0" ]; then


### PR DESCRIPTION
## Description of the change

> Adds support for the `GITHUB_TOKEN` environment variable. `GITHUB_TOKEN` is built-in in GitHub Actions to authenticate to GitHub's API. It's also commonly used outside of GitHub Actions.
> If this environment variable is not set, it will simply use the unauthenticated method.

## Type of change

- [x] New feature (non-breaking change that adds functionality);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
