### PR TITLE
Ensure autoscaler zip is present on disk

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -6,8 +6,8 @@ code_version=$1
 export code_architecture=$2
 
 if [ "$code_version" != "latest" ]; then
-  # If the code version is not latest, we dont need to hit the github api.
-  curl -L -o lambda.zip "https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
+  # If the code version is not latest, we don't need to hit the github api.
+  download_url="https://github.com/spacelift-io/ec2-workerpool-autoscaler/releases/download/${code_version}/ec2-workerpool-autoscaler_linux_${code_architecture}.zip"
 else
   # Make a temporary file to store the headers in
   tmpfile=$(mktemp /tmp/spacelift-request-headers.XXXXXX)
@@ -35,12 +35,7 @@ else
     echo "  Release Name: $code_version"
     echo "  Release Date: $release_date"
     echo "  Download URL: $download_url"
-
-    curl -L -o lambda.zip $download_url
   fi
 fi
 
-mkdir -p lambda
-cd lambda
-unzip -o ../lambda.zip
-rm ../lambda.zip
+curl -L -O "$download_url"


### PR DESCRIPTION
## Description of the change

Fixes #129

If `var.autoscaler_version` is set, the `null_resource` uses it as the `keeper` and won't trigger the provisioner again until the version number changes.

On CI runners that start with a clean workspace for each run (such as on Spacelift worker pools), the file won't be there on the next run, leading to an archive creation error from the `archive_file` data source on each subsequent plan or apply:

```text
Error: Archive creation error

  with module.spacelift_worker_pool_ec2.data.archive_file.binary[0],
  on .terraform/modules/spacelift_worker_pool_ec2/autoscaler.tf line 25,
  in data "archive_file" "binary":
  25: data "archive_file" "binary" {

error creating archive: error archiving file: could not archive missing
file: lambda/bootstrap
```

The current approach also pointlessly unzips the archive to `lambda/bootstrap`, then rezips it back to the same filename that was downloaded in the first place.

This PR will implement a fix by:

- Trigger the `null_resource` if `!fileexists()` so that the file will be present on disk.
- Instead of unzipping and rezipping the archive, just leave it as-is after download and replace `archive_file` with `local_file` that can reference the zip directly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
