### PR TITLE
Download ASG Lambda into a unique folder

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.14.1
+module_version: 2.14.2
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/download.sh
+++ b/download.sh
@@ -3,7 +3,8 @@ set -ex
 
 # Download the data.
 code_version=$1
-export code_architecture=$2
+code_architecture=$2
+downloadFolder=$3
 
 if [ "$code_version" != "latest" ]; then
   # If the code version is not latest, we dont need to hit the github api.
@@ -40,7 +41,7 @@ else
   fi
 fi
 
-mkdir -p lambda
-cd lambda
+mkdir -p "$downloadFolder"
+cd "$downloadFolder"
 unzip -o ../lambda.zip
 rm ../lambda.zip


### PR DESCRIPTION


## Description of the change

This is originally @denniskern 's contribution from: https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/75

Say this:

```hcl
module "my_workerpool" {
  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v2.13.0"

  for_each = [{name = "workerpool-1"}, {name = "workerpool-2"}]
  
  secure_env_vars = {
    SPACELIFT_TOKEN            = var.worker_pool_config
    SPACELIFT_POOL_PRIVATE_KEY = var.worker_pool_private_key
  }

  min_size          = 1
  max_size          = 5
  worker_pool_id    = each.value
  security_groups   = var.worker_pool_security_groups
  vpc_subnets       = var.worker_pool_subnets
}
```

It can happen that the autoscaler is downloaded at the same time, and it causes a race.
```
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.null_resource.download[0]: Creation complete after 1s [id=8647914972254941746]
module.worker_pools.module.spacelift_worker_pool["workerpool2"].module.workerpool.data.archive_file.binary[0]: Reading...
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: LICENSE
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: README.md
module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec):   inflating: bootstrap

module.worker_pools.module.spacelift_worker_pool["workerpool1"].module.workerpool.null_resource.download[0] (local-exec): rm: can't remove '../lambda.zip': No such file or directory

```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
