### PR TITLE
Bugfix for user data (secure env vars)

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 1
-module_version: 2.14.0
+module_version: 2.14.1
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64

--- a/secure_strings.tf
+++ b/secure_strings.tf
@@ -6,7 +6,7 @@ locals {
       for key, _ in var.secure_env_vars : "export ${key}=$(echo $SECRET_VALUE | jq -r '.${key}')"
     ]
   ) : ""
-  secure_env_vars = "export SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id ${local.base_name}-secret --query SecretString --output text)\n${local.secure_env_vars_exports}"
+  secure_env_vars = local.secure_env_vars_count > 0 ? "export SECRET_VALUE=$(aws secretsmanager get-secret-value --secret-id ${local.base_name}-secret --query SecretString --output text)\n${local.secure_env_vars_exports}" : ""
 }
 
 resource "aws_secretsmanager_secret" "this" {


### PR DESCRIPTION
## Description of the change

This'd add a new line to the userdata even if there is no secure env vars defined:

<img width="946" alt="image" src="https://github.com/user-attachments/assets/ebd674fa-e350-439b-af4a-61191eb9c7a7" />


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
