### PR TITLE
Get secure_env_vars KMS Key ARN

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 3.0.0
+module_version: 3.0.1
 
 tests:
   - name: AMD64-based workerpool

--- a/iam.tf
+++ b/iam.tf
@@ -75,6 +75,12 @@ resource "aws_iam_instance_profile" "this" {
   tags = var.additional_tags
 }
 
+data "aws_kms_key" "secure_env_vars" {
+  count = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
+
+  key_id = var.secure_env_vars_kms_key_id
+}
+
 data "aws_iam_policy_document" "secure_env_vars" {
   count = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
 
@@ -95,7 +101,7 @@ data "aws_iam_policy_document" "secure_env_vars" {
         "kms:DescribeKey",
         "kms:GenerateDataKey",
       ]
-      resources = [var.secure_env_vars_kms_key_id]
+      resources = [data.aws_kms_key.secure_env_vars[0].arn]
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -61,8 +61,12 @@ resource "aws_iam_role_policy" "s3" {
   })
 }
 
+locals {
+  use_secure_env_vars = alltrue([local.has_secure_env_vars, var.create_iam_role])
+}
+
 resource "aws_iam_role_policy_attachment" "secure_env_vars" {
-  count      = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
+  count      = local.use_secure_env_vars ? 1 : 0
   role       = aws_iam_role.this[0].name
   policy_arn = aws_iam_policy.secure_env_vars[0].arn
 }
@@ -76,13 +80,13 @@ resource "aws_iam_instance_profile" "this" {
 }
 
 data "aws_kms_key" "secure_env_vars" {
-  count = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
+  count = local.use_secure_env_vars ? 1 : 0
 
   key_id = var.secure_env_vars_kms_key_id
 }
 
 data "aws_iam_policy_document" "secure_env_vars" {
-  count = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
+  count = local.use_secure_env_vars ? 1 : 0
 
   statement {
     effect = "Allow"
@@ -107,7 +111,7 @@ data "aws_iam_policy_document" "secure_env_vars" {
 }
 
 resource "aws_iam_policy" "secure_env_vars" {
-  count = local.has_secure_env_vars && var.create_iam_role ? 1 : 0
+  count = local.use_secure_env_vars ? 1 : 0
 
   name        = "${local.base_name}-secure-strings"
   description = "Allows access to the secure strings stored in Secrets Manager"


### PR DESCRIPTION
## Description of the change

> The ARN of the KMS Key is required in the IAM Policy, not the ID. By using a data source we reduce the amount of information required from the user.
> Resolves <https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/140>

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
