### PR TITLE
Provides option to specify value for autoscaler log group retention

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 3.0.2
+module_version: 3.0.3
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provider "aws" {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -74,7 +74,7 @@ Example:
 
 ```hcl
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -99,7 +99,7 @@ For self-hosted, other than the aforementioned `SPACELIFT_TOKEN` and `SPACELIFT_
 
 ```terraform
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
 
   secure_env_vars = {
     SPACELIFT_TOKEN = var.worker_pool_config

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -92,5 +92,5 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
 
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = "/aws/lambda/${local.function_name}"
-  retention_in_days = 7
+  retention_in_days = var.cloudwatch_log_group.retention_in_days
 }

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -46,3 +46,12 @@ variable "iam_permissions_boundary" {
   type        = string
   description = "ARN of the policy that is used to set the permissions boundary for any IAM roles."
 }
+
+variable "cloudwatch_log_group" {
+  description = "Object of inputs for the autoscaler cloudwatch log group."
+  type = object({
+    retention_in_days = optional(number, 7)
+  })
+  nullable = false
+  default  = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module "autoscaler" {
   aws_partition_dns_suffix  = data.aws_partition.current.dns_suffix
   aws_region                = data.aws_region.this.name
   base_name                 = local.base_name
+  cloudwatch_log_group      = var.autoscaling_configuration.cloudwatch_log_group
   iam_permissions_boundary  = var.iam_permissions_boundary
   worker_pool_id            = var.worker_pool_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,8 @@ variable "autoscaling_configuration" {
   - max_create: (optional) The maximum number of instances the utility is allowed to create in a single run.
   - max_terminate: (optional) The maximum number of instances the utility is allowed to terminate in a single run.
   - timeout: (optional) Timeout (in seconds) for a single autoscaling run. The more instances you have, the higher this should be.
+  - cloudwatch_log_group: (optional) Object of inputs for the autoscaler log group.
+    - retention_in_days: (optional) The number of days to retain log events for the autoscaler log group. Default: 7.
   - s3_package: (optional) Configuration to retrieve autoscaler lambda package from a specific S3 bucket.
     - bucket: (mandatory) S3 bucket name
     - key: (mandatory) S3 object key
@@ -230,6 +232,9 @@ variable "autoscaling_configuration" {
     max_create          = optional(number)
     max_terminate       = optional(number)
     timeout             = optional(number)
+    cloudwatch_log_group = optional(object({
+      retention_in_days = optional(number, 7)
+    }), {})
     s3_package = optional(object({
       bucket         = string
       key            = string


### PR DESCRIPTION
## Description of the change

Provides option to specify value for autoscaler log group retention

Fixes https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/144


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
