### PR TITLE
fix: add missing variable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 3.0.3
+module_version: 3.1.3
 
 tests:
   - name: AMD64-based workerpool

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 3.1.3
+module_version: 3.0.4
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provider "aws" {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -74,7 +74,7 @@ Example:
 
 ```hcl
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -99,7 +99,7 @@ For self-hosted, other than the aforementioned `SPACELIFT_TOKEN` and `SPACELIFT_
 
 ```terraform
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
 
   secure_env_vars = {
     SPACELIFT_TOKEN = var.worker_pool_config

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ provider "aws" {
 }
 
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.4"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -74,7 +74,7 @@ Example:
 
 ```hcl
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.4"
   
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -99,7 +99,7 @@ For self-hosted, other than the aforementioned `SPACELIFT_TOKEN` and `SPACELIFT_
 
 ```terraform
 module "my_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.1.3"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v3.0.4"
 
   secure_env_vars = {
     SPACELIFT_TOKEN = var.worker_pool_config

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -19,12 +19,14 @@ resource "null_resource" "download" {
   triggers = {
     # Always re-download the archive file if the version is set to "latest" or if the file does not exist
     keeper = (
-      local.autoscaler_version == "latest" || !fileexists(local.autoscaler_zip)
+      local.autoscaler_version == "latest" || !fileexists(local.autoscaler_zip) && !var.is_managed
       ? timestamp()
       : local.autoscaler_version
     )
   }
-
+  // pinned to a version(false) and managed locally ==> dont download
+  // pinned to a version and managed by spacelift ==> dont download
+  // set to latest ==> download
   provisioner "local-exec" {
     command = "${path.module}/download.sh ${local.autoscaler_version} ${local.architecture} ${local.download_folder}"
   }

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -55,3 +55,9 @@ variable "cloudwatch_log_group" {
   nullable = false
   default  = {}
 }
+
+variable "is_managed" {
+  description = "If this module is being used and deployed via spacelift"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Description of the change

Currently, if you manage the worker pool via spacelift, and pin the autoscaler to a specific version, it will always redownload the binary. The expected behavior is if you're pinning it to a specific version, regardless whether it's managed by spacelift or not, it should not redownload the binary. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
