### PR TITLE
Retry lifecycle manager when no worker is found for a terminating instance

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 4.0.0
+module_version: 4.0.1
 
 tests:
   - name: AMD64-based workerpool

--- a/lifecycle_manager/main.py
+++ b/lifecycle_manager/main.py
@@ -187,3 +187,4 @@ def main(event, context):
                     put_message_back_on_queue(body)
         else:
             print(f"No worker found for instance ID {instance_id}.")
+            put_message_back_on_queue(body)


### PR DESCRIPTION
## Description of the change

If an instance is terminated immediately after starting (say for a unfortunately-timed instance refresh or something), it's very likely that the instance wouldn't have (yet) had a chance to
register itself with the pool.

When that happens, the lifecycle manager simply logs the "error" and moves along. This will leave the instance in a 'terminate:wait' state until the lifecycle hook times out. Given the default behavior of 'CONTINUE', this will indefinitely leave those instances in the
ASG, but doing nothing.

This will put the SQS message back in the queue, retrying it after the normal back-off timeout.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
