### PR TITLE
feat: Expose autoscaler VPC config to the root module

### DIFF
--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -47,10 +47,10 @@ resource "aws_lambda_function" "autoscaler" {
   timeout       = var.autoscaling_configuration.timeout != null ? var.autoscaling_configuration.timeout : 30
 
   dynamic "vpc_config" {
-    for_each = var.subnet_ids != null && var.security_group_ids != null ? ["USE_VPC_CONFIG"] : []
+    for_each = var.spacelift_vpc_subnet_ids != null && var.spacelift_vpc_security_group_ids != null ? ["USE_VPC_CONFIG"] : []
     content {
-      security_group_ids          = var.security_group_ids
-      subnet_ids                  = var.subnet_ids
+      security_group_ids          = var.spacelift_vpc_security_group_ids
+      subnet_ids                  = var.spacelift_vpc_subnet_ids
       ipv6_allowed_for_dual_stack = var.ipv6_allowed_for_dual_stack
     }
   }

--- a/autoscaler/iam.tf
+++ b/autoscaler/iam.tf
@@ -45,6 +45,19 @@ data "aws_iam_policy_document" "autoscaler" {
     resources = ["*"]
   }
 
+  # Allow the Lambda to take actions on NetworkInterfaces
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeInstances",
+      "ec2:AttachNetworkInterface"
+    ]
+    resources = ["*"]
+  }
+
   # Allow the Lambda to read the secret from SSM Parameter Store.
   statement {
     effect    = "Allow"

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -74,13 +74,13 @@ variable "api_key_ssm_parameter_arn" {
   type = string
 }
 
-variable "subnet_ids" {
+variable "spacelift_vpc_subnet_ids" {
   description = "List of subnet IDs when the lambda function should run in a VPC."
   type        = list(string)
   default     = null
 }
 
-variable "security_group_ids" {
+variable "spacelift_vpc_security_group_ids" {
   description = "List of security group IDs when the lambda function should run in a VPC."
   type        = list(string)
   default     = null

--- a/main.tf
+++ b/main.tf
@@ -23,18 +23,20 @@ module "autoscaler" {
   count  = local.autoscaling_enabled ? 1 : 0
   source = "./autoscaler"
 
-  additional_tags                = var.additional_tags
-  api_key_ssm_parameter_arn      = local.ssm_arn
-  api_key_ssm_parameter_name     = local.ssm_name
-  auto_scaling_group_arn         = module.asg.autoscaling_group_arn
-  autoscaling_configuration      = var.autoscaling_configuration
-  aws_partition_dns_suffix       = data.aws_partition.current.dns_suffix
-  aws_region                     = data.aws_region.this.name
-  base_name                      = local.base_name
-  cloudwatch_log_group_retention = var.cloudwatch_log_group_retention
-  spacelift_api_credentials      = var.spacelift_api_credentials
-  iam_permissions_boundary       = var.iam_permissions_boundary
-  worker_pool_id                 = var.worker_pool_id
+  additional_tags                  = var.additional_tags
+  api_key_ssm_parameter_arn        = local.ssm_arn
+  api_key_ssm_parameter_name       = local.ssm_name
+  auto_scaling_group_arn           = module.asg.autoscaling_group_arn
+  autoscaling_configuration        = var.autoscaling_configuration
+  aws_partition_dns_suffix         = data.aws_partition.current.dns_suffix
+  aws_region                       = data.aws_region.this.name
+  base_name                        = local.base_name
+  cloudwatch_log_group_retention   = var.cloudwatch_log_group_retention
+  spacelift_api_credentials        = var.spacelift_api_credentials
+  iam_permissions_boundary         = var.iam_permissions_boundary
+  worker_pool_id                   = var.worker_pool_id
+  spacelift_vpc_subnet_ids         = var.autoscaling_vpc_subnets
+  spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
 }
 
 module "lifecycle_manager" {

--- a/variables.tf
+++ b/variables.tf
@@ -269,6 +269,18 @@ variable "autoscaling_configuration" {
   default = null
 }
 
+variable "autoscaling_vpc_subnets" {
+  description = "List of VPC subnets to use for the autoscaler Lambda function."
+  type        = list(string)
+  default     = null
+}
+
+variable "autoscaling_vpc_sg_ids" {
+  description = "values of the security group to use for the autoscaler Lambda function."
+  type        = list(string)
+  default     = null
+}
+
 variable "selfhosted_configuration" {
   description = <<EOF
   Configuration for selfhosted launcher. Configuration options are:


### PR DESCRIPTION
## Description of the change
This PR exposes the autoscaler configuration in the root module. This allows the autoscaler Lambda to be attached to the VPC directly from the `terraform-aws-spacelift-workerpool-on-ec2` module. It also fixes an issue with the IAM roles for the Lambda.

This PR adjust the change made by @jubranNassar.
## Type of change

- [X] Bug fix (non-breaking change that fixes an issue);
- [X] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [X] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
