### PR TITLE
feat: download correct binary when in FedRAMP environment

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.2.0
+module_version: 5.3.0
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ provider "aws" {
 }
 
 module "spacelift_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.2.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.3.0"
 
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config
@@ -55,6 +55,8 @@ module "spacelift_workerpool" {
   vpc_subnets       = var.subnets
 }
 ```
+
+### Other Examples
 
 For more examples covering specific use cases, please see the [examples directory](./examples/):
 

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -12,12 +12,25 @@ spacelift () {(
     return 1
   fi
 
-  baseURL="https://downloads.${domain_name}/spacelift-launcher"
+  # Check if we're connecting to FedRAMP environment by decoding SPACELIFT_TOKEN
+  fedrampSuffix=""
+  if [[ -n "$SPACELIFT_TOKEN" ]]; then
+    # Decode the base64 token and extract broker endpoint
+    decoded_token=$(echo "$SPACELIFT_TOKEN" | base64 -d 2>/dev/null || echo "")
+    if [[ -n "$decoded_token" ]]; then
+      broker_endpoint=$(echo "$decoded_token" | jq -r '.broker.endpoint' 2>/dev/null || echo "")
+      if [[ "$broker_endpoint" == *".gov.spacelift.io" ]]; then
+        fedrampSuffix="-fedramp"
+      fi
+    fi
+  fi
+  
+  baseURL="https://downloads.${domain_name}/spacelift-launcher$fedrampSuffix"
   binaryURL=$(printf "%s-%s" "$baseURL" "$currentArch")
   shaSumURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS")
   shaSumSigURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS.sig")
 
-  echo "Downloading Spacelift launcher" >> /var/log/spacelift/info.log
+  echo "Downloading Spacelift launcher from $binaryURL" >> /var/log/spacelift/info.log
   curl "$binaryURL" --output /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
 
   echo "Importing public GPG key" >> /var/log/spacelift/info.log


### PR DESCRIPTION
## Description of the change

I've updated the startup script to check whether it's connecting to the MQTT broker for our FedRAMP environment. If so it downloads the FedRAMP-specific version of the launcher.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [x] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [x] Reviewers have been assigned;
- [x] Changes have been reviewed by at least one other engineer;
