### PR TITLE
feat: dont register instance when metadata service give us bad results

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.4.1
+module_version: 5.4.2
 
 tests:
   - name: AMD64-based workerpool

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -65,12 +65,26 @@ spacelift () {(
   echo "Making the Spacelift launcher executable" >> /var/log/spacelift/info.log
   chmod 755 /usr/bin/spacelift-launcher 2>>/var/log/spacelift/error.log
 
+  validate_metadata() {
+    local value="$1"
+    local name="$2"
+    if [[ -z "$value" ]] || [[ "$value" == "null" ]] || [[ "$value" == "None" ]]; then
+      echo "ERROR: $name is null or empty. EC2 metadata service returned invalid data." >> /var/log/spacelift/error.log
+      return 1
+    fi
+    return 0
+  }
+
   echo "Retrieving EC2 instance id and AMI id" >> /var/log/spacelift/info.log
   export SPACELIFT_METADATA_instance_id=$(ec2-metadata --instance-id | cut -d ' ' -f2)
+  validate_metadata "$SPACELIFT_METADATA_instance_id" "instance_id" || return 1
+
   export SPACELIFT_METADATA_ami_id=$(ec2-metadata --ami-id | cut -d ' ' -f2)
+  validate_metadata "$SPACELIFT_METADATA_ami_id" "ami_id" || return 1
 
   echo "Retrieving EC2 ASG ID" >> /var/log/spacelift/info.log
   export SPACELIFT_METADATA_asg_id=$(aws autoscaling --region=${region} describe-auto-scaling-instances --instance-ids $SPACELIFT_METADATA_instance_id | jq -r '.AutoScalingInstances[0].AutoScalingGroupName')
+  validate_metadata "$SPACELIFT_METADATA_asg_id" "asg_id" || return 1
 
   echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
   /usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -77,11 +77,25 @@ create_spacelift_launcher_script () {(
 #!/bin/bash
 join_strings () { local d="$1"; echo -n "$2"; shift 2 && printf '%s' "$${!@/#/$d}"; }
 
+validate_metadata() {
+  local value="\$1"
+  local name="\$2"
+  if [[ -z "\$value" ]] || [[ "\$value" == "null" ]] || [[ "\$value" == "None" ]]; then
+    echo "ERROR: \$name is null or empty. EC2 metadata service returned invalid data." >> /var/log/spacelift/error.log
+    exit 1
+  fi
+}
+
 echo "Retrieving EC2 instance ID and ami ID" >> /var/log/spacelift/info.log
 export SPACELIFT_METADATA_instance_id=\$(ec2-metadata --instance-id | cut -d ' ' -f2)
+validate_metadata "\$SPACELIFT_METADATA_instance_id" "instance_id"
+
 export SPACELIFT_METADATA_ami_id=\$(ec2-metadata --ami-id | cut -d ' ' -f2)
+validate_metadata "\$SPACELIFT_METADATA_ami_id" "ami_id"
+
 echo "Retrieving EC2 ASG ID" >> /var/log/spacelift/info.log
 export SPACELIFT_METADATA_asg_id=\$(aws autoscaling --region=${region} describe-auto-scaling-instances --instance-ids \$SPACELIFT_METADATA_instance_id | jq -r '.AutoScalingInstances[0].AutoScalingGroupName')
+validate_metadata "\$SPACELIFT_METADATA_asg_id" "asg_id"
 if [[ "${http_proxy_config}" != "" || "${https_proxy_config}" != "" || "${no_proxy_config}" != "" ]]; then
   whitelisted_vars=()
   echo "Configuring HTTP proxy information" >> /var/log/spacelift/info.log


### PR DESCRIPTION
## Summary

Adds validation to prevent worker pool instances from registering when the EC2 metadata service returns null or invalid values for critical instance metadata.

## Motivation

In rare cases, the EC2 metadata service can return null, empty, or malformed responses for instance metadata queries. When this happens, worker pool instances would attempt to register with Spacelift using invalid metadata (null instance IDs, AMI IDs, or ASG names), which can cause registration failures, tracking issues, or unexpected behavior in the worker pool management system.

This defensive validation prevents instances from proceeding with the registration process when they receive bad data from the metadata service, failing fast with clear error messages instead of propagating invalid state.

## Changes

- Added `validate_metadata()` function to both SaaS and self-hosted user data templates
- Validates `instance_id`, `ami_id`, and `asg_id` after retrieval from EC2 metadata service
- Checks for empty strings, "null", and "None" values
- Logs descriptive errors to `/var/log/spacelift/error.log` when validation fails
- Prevents launcher from starting when metadata validation fails
- Bumped module version to 5.4.2

## Fixes

- Prevents worker pool instances from registering with invalid/null metadata when EC2 metadata service returns malformed responses
- Provides clear error logging for troubleshooting metadata service issues
- Avoids downstream issues caused by instances running with null or invalid identity metadata

## Behavior

When an instance receives invalid metadata from the EC2 metadata service:
- **SaaS template**: The `spacelift()` function returns early (exit code 1), preventing launcher startup
- **Self-hosted template**: The launcher script exits immediately with exit code 1
- Both cases log a descriptive error message indicating which metadata field failed validation

This fail-fast behavior ensures that only instances with valid metadata can register with the worker pool, making it easier to identify and troubleshoot metadata service issues rather than dealing with mysteriously broken instances.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add EC2 metadata validation to SaaS and self-hosted user data to fail fast on invalid values; bump module version to 5.4.2.
> 
> - **User data templates**:
>   - `user_data/saas.tftpl`: Add `validate_metadata` and validate `instance_id`, `ami_id`, `asg_id`; log errors and `return 1` to prevent launcher start when invalid.
>   - `user_data/selfhosted.tftpl`: Add `validate_metadata` in `run-launcher.sh`; validate `instance_id`, `ami_id`, `asg_id`; log errors and `exit 1` on failure.
> - **Version**:
>   - `.spacelift/config.yml`: Bump `module_version` to `5.4.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a717566ad79b17b52958ae6de6e4bbaab5b66c9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->