### PR TITLE
feat: manage CloudWatch Log Groups

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -48,3 +48,9 @@ tests:
       TF_VAR_spacelift_api_key_id: "EXAMPLE0VOYU49U485BMZZVAWXU59JOEY1"
       TF_VAR_spacelift_api_key_secret: "EXAMPLE22anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
+
+  - name: Cloudwatch Import
+    project_root: examples/cloudwatch-import
+    before_init:
+      - aws logs create-log-group --log-group-name spacelift-info.log 2>/dev/null || true
+      - aws logs create-log-group --log-group-name spacelift-errors.log 2>/dev/null || true

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.4.2
+module_version: 5.5.0
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ provider "aws" {
 }
 
 module "spacelift_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.3.1"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.5.0"
 
   secure_env_vars = {
     SPACELIFT_TOKEN            = var.worker_pool_config

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,22 @@
+# Log group names are hardcoded to match the awslogs agent configuration in the
+# Spacelift worker AMI (https://github.com/spacelift-io/spacelift-worker-image).
+
+resource "aws_cloudwatch_log_group" "spacelift_info" {
+  name                        = "spacelift-info.log"
+  retention_in_days           = var.cloudwatch_log_group_retention
+  kms_key_id                  = var.cloudwatch_kms_key_id
+  skip_destroy                = var.cloudwatch_skip_destroy
+  deletion_protection_enabled = var.cloudwatch_deletion_protection_enabled
+  log_group_class             = var.cloudwatch_log_group_class
+  tags                        = var.additional_tags
+}
+
+resource "aws_cloudwatch_log_group" "spacelift_errors" {
+  name                        = "spacelift-errors.log"
+  retention_in_days           = var.cloudwatch_log_group_retention
+  kms_key_id                  = var.cloudwatch_kms_key_id
+  skip_destroy                = var.cloudwatch_skip_destroy
+  deletion_protection_enabled = var.cloudwatch_deletion_protection_enabled
+  log_group_class             = var.cloudwatch_log_group_class
+  tags                        = var.additional_tags
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,18 +1,14 @@
 # Log group names are hardcoded to match the awslogs agent configuration in the
 # Spacelift worker AMI (https://github.com/spacelift-io/spacelift-worker-image).
 
-resource "aws_cloudwatch_log_group" "spacelift_info" {
-  name                        = "spacelift-info.log"
-  retention_in_days           = var.cloudwatch_log_group_retention
-  kms_key_id                  = var.cloudwatch_kms_key_id
-  skip_destroy                = var.cloudwatch_skip_destroy
-  deletion_protection_enabled = var.cloudwatch_deletion_protection_enabled
-  log_group_class             = var.cloudwatch_log_group_class
-  tags                        = var.additional_tags
+locals {
+  log_groups = toset(["spacelift-info.log", "spacelift-errors.log"])
 }
 
-resource "aws_cloudwatch_log_group" "spacelift_errors" {
-  name                        = "spacelift-errors.log"
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = local.log_groups
+
+  name                        = each.key
   retention_in_days           = var.cloudwatch_log_group_retention
   kms_key_id                  = var.cloudwatch_kms_key_id
   skip_destroy                = var.cloudwatch_skip_destroy

--- a/examples/cloudwatch-import/README.md
+++ b/examples/cloudwatch-import/README.md
@@ -1,0 +1,3 @@
+# Import CloudWatch Log Groups
+
+This is an example where the CloudWatch Log Groups already exist and we want to manage them with the module.

--- a/examples/cloudwatch-import/main.tf
+++ b/examples/cloudwatch-import/main.tf
@@ -1,0 +1,89 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+
+    random = { source = "hashicorp/random" }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      TfModule = "terraform-aws-spacelift-workerpool-on-ec2"
+      TestCase = "cloudwatch-import"
+    }
+  }
+}
+
+data "aws_vpc" "this" {
+  default = true
+}
+
+data "aws_security_group" "this" {
+  name   = "default"
+  vpc_id = data.aws_vpc.this.id
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+resource "random_string" "worker_pool_id" {
+  length  = 26
+  numeric = true
+  # Use special and override special to allow only uppercase letters and numbers
+  # but exclude I, L, O, and U as it does not conform to the regex used by Spacelift
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
+#### Spacelift worker pool ####
+
+module "this" {
+  source = "../../"
+
+  configuration = <<-EOT
+    export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
+    export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
+  EOT
+  secure_env_vars = {
+    SPACELIFT_TOKEN            = "<token-here>"
+    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  }
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+  worker_pool_id  = random_string.worker_pool_id.id
+
+  import_cloudwatch_log_groups = true
+
+  tag_specifications = [
+    {
+      resource_type = "instance"
+      tags = {
+        Name = "sp5ft-${random_string.worker_pool_id.id}"
+      }
+    },
+    {
+      resource_type = "volume"
+      tags = {
+        Name = "sp5ft-${random_string.worker_pool_id.id}"
+      }
+    },
+    {
+      resource_type = "network-interface"
+      tags = {
+        Name = "sp5ft-${random_string.worker_pool_id.id}"
+      }
+    }
+  ]
+}

--- a/imports.tf
+++ b/imports.tf
@@ -1,9 +1,5 @@
 import {
-  to = aws_cloudwatch_log_group.spacelift_info
-  id = "spacelift-info.log"
-}
-
-import {
-  to = aws_cloudwatch_log_group.spacelift_errors
-  id = "spacelift-errors.log"
+  for_each = var.import_cloudwatch_log_groups ? local.log_groups : toset([])
+  to       = aws_cloudwatch_log_group.this[each.key]
+  id       = each.key
 }

--- a/imports.tf
+++ b/imports.tf
@@ -1,0 +1,9 @@
+import {
+  to = aws_cloudwatch_log_group.spacelift_info
+  id = "spacelift-info.log"
+}
+
+import {
+  to = aws_cloudwatch_log_group.spacelift_errors
+  id = "spacelift-errors.log"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,12 +28,7 @@ output "secretsmanager_secret_arn" {
   description = "ARN of the secret in Secrets Manager that holds the encrypted environment variables."
 }
 
-output "spacelift_info_log_group_arn" {
-  description = "ARN of the spacelift-info.log CloudWatch log group"
-  value       = aws_cloudwatch_log_group.spacelift_info.arn
-}
-
-output "spacelift_errors_log_group_arn" {
-  description = "ARN of the spacelift-errors.log CloudWatch log group"
-  value       = aws_cloudwatch_log_group.spacelift_errors.arn
+output "log_group_arns" {
+  description = "Map of CloudWatch Log Group names to their ARNs"
+  value       = { for name, lg in aws_cloudwatch_log_group.this : name => lg.arn }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "secretsmanager_secret_arn" {
   value       = aws_secretsmanager_secret.this.*.arn
   description = "ARN of the secret in Secrets Manager that holds the encrypted environment variables."
 }
+
+output "spacelift_info_log_group_arn" {
+  description = "ARN of the spacelift-info.log CloudWatch log group"
+  value       = aws_cloudwatch_log_group.spacelift_info.arn
+}
+
+output "spacelift_errors_log_group_arn" {
+  description = "ARN of the spacelift-errors.log CloudWatch log group"
+  value       = aws_cloudwatch_log_group.spacelift_errors.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -238,23 +238,23 @@ variable "instance_refresh" {
 
 variable "instance_market_options" {
   description = <<EOF
-  The market (purchasing) option for the instance. Configuration block for setting 
+  The market (purchasing) option for the instance. Configuration block for setting
   up an instance on Spot vs On-Demand markets in the launch template.
 
   Configuration:
   - market_type: (Required) Type of market for the instance. Valid values: "spot"
   - spot_options: (Optional) Block to configure the Spot request
-    - max_price: (Optional) The maximum hourly price you're willing to pay for the instance. 
-      If not specified, you will pay the current Spot price (recommended). AWS does not 
-      recommend using this parameter as it can lead to increased interruptions. 
+    - max_price: (Optional) The maximum hourly price you're willing to pay for the instance.
+      If not specified, you will pay the current Spot price (recommended). AWS does not
+      recommend using this parameter as it can lead to increased interruptions.
       The price will never exceed the On-Demand price. Format: "0.05" (string)
-    - spot_instance_type: (Optional) The Spot instance request type. For Auto Scaling Groups, 
-      use "one-time" as ASG handles requesting new instances. Valid values: 
+    - spot_instance_type: (Optional) The Spot instance request type. For Auto Scaling Groups,
+      use "one-time" as ASG handles requesting new instances. Valid values:
       "one-time" (recommended for ASG) or "persistent"
-    - instance_interruption_behavior: (Optional) Indicates Spot instance behavior when 
-      interrupted. Valid values: "terminate" (default), "stop", or "hibernate". 
+    - instance_interruption_behavior: (Optional) Indicates Spot instance behavior when
+      interrupted. Valid values: "terminate" (default), "stop", or "hibernate".
       For persistent requests, "stop" and "hibernate" are valid.
-    - block_duration_minutes: (Optional, Deprecated) The required duration for Spot block 
+    - block_duration_minutes: (Optional, Deprecated) The required duration for Spot block
       instances in minutes. Note: Spot blocks are deprecated by AWS.
 
   Example configuration for spot instances:
@@ -266,14 +266,14 @@ variable "instance_market_options" {
       # max_price omitted to use current Spot price (recommended)
     }
   }
-  
-  ⚠️ WARNING: Spot instances are NOT recommended for critical workloads as they can be 
+
+  ⚠️ WARNING: Spot instances are NOT recommended for critical workloads as they can be
   interrupted with only 2 minutes notice, potentially causing:
   - Incomplete or corrupted Terraform state
   - Failed deployments leaving infrastructure in inconsistent state
   - Loss of work-in-progress for long-running operations
   Use only for non-critical development, testing, or ephemeral workloads.
-  
+
   Note: Auto Scaling Groups only support 'one-time' Spot instance requests with no duration.
   EOF
   type        = any
@@ -396,9 +396,33 @@ variable "spacelift_api_credentials" {
 }
 
 variable "cloudwatch_log_group_retention" {
-  description = "Retention period for the autoscaler and lifecycle manager cloudwatch log group."
+  description = "Retention period for the autoscaler and lifecycle manager CloudWatch log groups."
   type        = number
-  default     = 7
+  default     = 60
+}
+
+variable "cloudwatch_kms_key_id" {
+  description = "ARN of the KMS key to use for encrypting CloudWatch log groups."
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_skip_destroy" {
+  description = "Set to true to keep the log group and its logs when destroying the resource, only removing it from state."
+  type        = bool
+  default     = null
+}
+
+variable "cloudwatch_deletion_protection_enabled" {
+  description = "Whether deletion protection is enabled for the CloudWatch log groups."
+  type        = bool
+  default     = null
+}
+
+variable "cloudwatch_log_group_class" {
+  description = "The log class of the CloudWatch log groups. Possible values are STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+  type        = string
+  default     = null
 }
 
 variable "extra_iam_statements" {

--- a/variables.tf
+++ b/variables.tf
@@ -396,33 +396,39 @@ variable "spacelift_api_credentials" {
 }
 
 variable "cloudwatch_log_group_retention" {
-  description = "Retention period for the autoscaler and lifecycle manager CloudWatch log groups."
+  description = "Retention period for the autoscaler and lifecycle manager CloudWatch Log Groups."
   type        = number
   default     = 60
 }
 
 variable "cloudwatch_kms_key_id" {
-  description = "ARN of the KMS key to use for encrypting CloudWatch log groups."
+  description = "ARN of the KMS Key to use for encrypting CloudWatch Log Groups."
   type        = string
   default     = null
 }
 
 variable "cloudwatch_skip_destroy" {
-  description = "Set to true to keep the log group and its logs when destroying the resource, only removing it from state."
+  description = "Set to true to keep the Log Group and its logs when destroying the resource, only removing it from state."
   type        = bool
   default     = null
 }
 
 variable "cloudwatch_deletion_protection_enabled" {
-  description = "Whether deletion protection is enabled for the CloudWatch log groups."
+  description = "Whether deletion protection is enabled for the CloudWatch Log Groups."
   type        = bool
   default     = null
 }
 
 variable "cloudwatch_log_group_class" {
-  description = "The log class of the CloudWatch log groups. Possible values are STANDARD, INFREQUENT_ACCESS, or DELIVERY."
+  description = "The log class of the CloudWatch Log Groups."
   type        = string
   default     = null
+}
+
+variable "import_cloudwatch_log_groups" {
+  description = "Whether to import existing CloudWatch Log Groups created by the awslogs agent into state. Set to true if the Log Groups already exist."
+  type        = bool
+  default     = false
 }
 
 variable "extra_iam_statements" {


### PR DESCRIPTION
## Description of the change

> Imports and manages the CloudWatch Log Groups used by the private workers, and sets a sane default for retention (same as log retention in Spacelift).
> Resolves <https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/189>

## Type of change

- [X] New feature (non-breaking change that adds functionality);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Creates/imports CloudWatch Log Group resources and changes default retention, which can affect existing logging setups and Terraform state (especially when importing or destroying).
> 
> **Overview**
> Adds module-managed `aws_cloudwatch_log_group` resources for the worker AMI’s `spacelift-info.log` and `spacelift-errors.log`, plus an optional `import` block gated by `import_cloudwatch_log_groups` to adopt pre-existing log groups into state.
> 
> Introduces new CloudWatch-related inputs (KMS key, skip-destroy, deletion protection, class) and changes the default `cloudwatch_log_group_retention` from 7 to 60 days, and exports `log_group_arns`.
> 
> Updates the module version/reference to `v5.5.0` and adds a `cloudwatch-import` example wired into Spacelift CI (including pre-creating log groups before init).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae6f1b2d0bfe0ea1ae515099b1bd6eef7c8d2df2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->