### PR TITLE
Feat/disable cloudwatch agent

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.4.2
+module_version: 5.5.0
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -243,6 +243,43 @@ The Spacelift worker includes built-in spot instance interruption detection to m
 
 For a complete example, see the [spot instances example](./examples/spot-instances/).
 
+## 📊 CloudWatch Agent Cost Management
+
+The Spacelift worker AMI comes with the CloudWatch Agent pre-installed and enabled by default. This agent collects detailed instance-level metrics (CPU, memory, disk usage, etc.) which are sent to CloudWatch.
+
+### Cost Implications
+
+While CloudWatch metrics provide valuable observability, they can incur significant costs:
+- CloudWatch custom metrics are charged per metric per month
+- For some use cases, the cost of CloudWatch metrics can exceed the cost of the EC2 instances themselves
+- This is separate from the free Auto Scaling Group metrics (controlled by the `enabled_metrics` variable)
+
+### Disabling the CloudWatch Agent
+
+If you don't need detailed instance-level metrics, you can disable the CloudWatch Agent to reduce costs:
+
+```hcl
+module "spacelift_workerpool" {
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2"
+
+  # ... other configuration ...
+
+  # Disable CloudWatch Agent to reduce costs
+  disable_cloudwatch_agent = true
+}
+```
+
+When `disable_cloudwatch_agent` is set to `true`:
+1. The CloudWatch Agent service is stopped and disabled on instance startup
+2. The `CloudWatchAgentServerPolicy` IAM policy is not attached to the instance role
+3. No instance-level custom metrics are collected or sent to CloudWatch
+
+**Note**: This setting only affects the CloudWatch Agent. The free Auto Scaling Group metrics (like GroupDesiredCapacity, GroupInServiceInstances, etc.) configured via the `enabled_metrics` variable are not affected.
+
+### Default Behavior
+
+For backward compatibility, the CloudWatch Agent remains **enabled by default** (`disable_cloudwatch_agent = false`). Existing deployments will continue to work as before unless you explicitly set this variable to `true`.
+
 ## Default AMI
 
 The default AMI used by this module comes from the [spacelift-worker-image](https://github.com/spacelift-io/spacelift-worker-image) repository. You can find the full list of AMIs on the [releases](https://github.com/spacelift-io/spacelift-worker-image/releases) page.

--- a/asg.tf
+++ b/asg.tf
@@ -11,13 +11,15 @@ locals {
     ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
+    disable_cloudwatch_agent       = var.disable_cloudwatch_agent
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {
-    custom_user_data = join("\n", [local.secure_env_vars, var.configuration])
-    domain_name      = var.domain_name
-    poweroff_delay   = var.poweroff_delay
-    region           = data.aws_region.this.region
+    custom_user_data         = join("\n", [local.secure_env_vars, var.configuration])
+    domain_name              = var.domain_name
+    poweroff_delay           = var.poweroff_delay
+    region                   = data.aws_region.this.region
+    disable_cloudwatch_agent = var.disable_cloudwatch_agent
   })
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -61,7 +61,7 @@ locals {
     ] : [],
     local.lifecycle_manager_enabled ? [
       "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AutoScalingNotificationAccessRole"
-    ] : []) : []
+  ] : []) : []
 }
 resource "aws_iam_role_policy_attachment" "this" {
   for_each = toset(local.iam_managed_policies)

--- a/iam.tf
+++ b/iam.tf
@@ -54,11 +54,14 @@ resource "aws_iam_role" "this" {
 locals {
   iam_managed_policies = var.create_iam_role ? concat([
     "arn:${data.aws_partition.current.partition}:iam::aws:policy/AutoScalingReadOnlyAccess",
-    "arn:${data.aws_partition.current.partition}:iam::aws:policy/CloudWatchAgentServerPolicy",
     "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
-    ], local.lifecycle_manager_enabled ? [
-    "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AutoScalingNotificationAccessRole"
-  ] : []) : []
+    ],
+    !var.disable_cloudwatch_agent ? [
+      "arn:${data.aws_partition.current.partition}:iam::aws:policy/CloudWatchAgentServerPolicy"
+    ] : [],
+    local.lifecycle_manager_enabled ? [
+      "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AutoScalingNotificationAccessRole"
+    ] : []) : []
 }
 resource "aws_iam_role_policy_attachment" "this" {
   for_each = toset(local.iam_managed_policies)

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -3,6 +3,13 @@
 spacelift () {(
   set -e
 
+  %{ if disable_cloudwatch_agent ~}
+  echo "Stopping and disabling CloudWatch Agent" >> /var/log/spacelift/info.log
+  sudo systemctl stop amazon-cloudwatch-agent 2>>/var/log/spacelift/error.log || true
+  sudo systemctl disable amazon-cloudwatch-agent 2>>/var/log/spacelift/error.log || true
+  echo "CloudWatch Agent has been disabled" >> /var/log/spacelift/info.log
+  %{ endif ~}
+
   ${custom_user_data}
 
   currentArch=$(uname -m)

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+disable_cloudwatch_agent () {(
+  %{ if disable_cloudwatch_agent ~}
+  echo "Stopping and disabling CloudWatch Agent" >> /var/log/spacelift/info.log
+  sudo systemctl stop amazon-cloudwatch-agent 2>>/var/log/spacelift/error.log || true
+  sudo systemctl disable amazon-cloudwatch-agent 2>>/var/log/spacelift/error.log || true
+  echo "CloudWatch Agent has been disabled" >> /var/log/spacelift/info.log
+  %{ else ~}
+  echo "CloudWatch Agent remains enabled" >> /var/log/spacelift/info.log
+  %{ endif ~}
+)}
+
 configure_permissions () {(
   set -e
   if [[ "${run_launcher_as_spacelift_user}" == "false" ]]; then
@@ -141,6 +152,7 @@ run_spacelift () {(
   fi
 )}
 
+disable_cloudwatch_agent
 configure_permissions
 download_launcher
 configure_docker

--- a/variables.tf
+++ b/variables.tf
@@ -406,3 +406,18 @@ variable "extra_iam_statements" {
   type        = list(string)
   default     = []
 }
+
+variable "disable_cloudwatch_agent" {
+  description = <<EOF
+  If true, the CloudWatch Agent (pre-installed in the AMI) will be stopped and disabled on instance startup.
+  This also prevents the CloudWatchAgentServerPolicy from being attached to the IAM role.
+
+  Note: This only affects the CloudWatch Agent running on the EC2 instances, which collects detailed
+  instance-level metrics (CPU, memory, disk, etc.) that incur costs. The free Auto Scaling Group metrics
+  (controlled by the `enabled_metrics` variable) are not affected by this setting.
+
+  Default: false (CloudWatch Agent remains enabled for backward compatibility)
+  EOF
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [x] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change gated by a new variable; primary impact is reduced metrics/permissions when enabled.
> 
> **Overview**
> Adds optional cost controls for CloudWatch by introducing `disable_cloudwatch_agent` (default `false`) to stop/disable the CloudWatch Agent in both SaaS and self-hosted user data and to *skip attaching* `CloudWatchAgentServerPolicy` to the instance role when disabled.
> 
> Updates docs with cost rationale and usage guidance, and bumps the module version to `5.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35c6ace51d9847e06d4e93c20f6d501900951837. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->