### PR TITLE
docs: clarification on CloudWatch Agent metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,9 @@ For a complete example, see the [spot instances example](./examples/spot-instanc
 
 ## 📊 CloudWatch Agent Cost Management
 
-The Spacelift worker AMI comes with the CloudWatch Agent pre-installed and enabled by default. This agent collects detailed instance-level metrics (CPU, memory, disk usage, etc.) which are sent to CloudWatch.
+The Spacelift worker AMI comes with the CloudWatch Agent pre-installed and enabled by default. This agent collects detailed, process-level metrics (e.g. per-process CPU and memory usage, fine-grained disk and network stats — see the [CloudWatch Agent metrics reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/metrics-collected-by-CloudWatch-agent.html#linux-metrics-enabled-by-CloudWatch-agent)) as well as Spacelift-specific custom metrics configured in the AMI, which are sent to CloudWatch as custom metrics.
+
+**Note**: Standard EC2 instance metrics such as CPU utilization, network I/O, and disk I/O are reported by the EC2 hypervisor and remain visible in CloudWatch regardless of whether the CloudWatch Agent is enabled or disabled.
 
 ### Cost Implications
 
@@ -272,7 +274,7 @@ module "spacelift_workerpool" {
 When `disable_cloudwatch_agent` is set to `true`:
 1. The CloudWatch Agent service is stopped and disabled on instance startup
 2. The `CloudWatchAgentServerPolicy` IAM policy is not attached to the instance role
-3. No instance-level custom metrics are collected or sent to CloudWatch
+3. No detailed process-level or Spacelift custom metrics are collected or sent to CloudWatch (standard EC2 hypervisor metrics such as CPU utilization remain visible)
 
 **Note**: This setting only affects the CloudWatch Agent. The free Auto Scaling Group metrics (like GroupDesiredCapacity, GroupInServiceInstances, etc.) configured via the `enabled_metrics` variable are not affected.
 


### PR DESCRIPTION
Only docs changes.

Follow up on previous PR (https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/193)

EC2 instance level metrics such as CPU & memory utilization is ALWAYS there. The CloudWatch Agent is only responsible for custom metrics (e.g. Spacelift runs, ) and the process level metrics. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates clarifying what metrics the CloudWatch Agent publishes and that standard EC2 hypervisor metrics remain available even when the agent is disabled.
> 
> **Overview**
> Clarifies the `CloudWatch Agent` section in `README.md` to distinguish **process-level + Spacelift custom metrics** (published by the agent as custom CloudWatch metrics) from **standard EC2 hypervisor metrics** that remain visible regardless of agent state.
> 
> Updates the `disable_cloudwatch_agent` behavior description to explicitly state that disabling stops agent-provided detailed/custom metrics while leaving default EC2 metrics unaffected, and adds a link to AWS’s CloudWatch Agent metrics reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41d92a6ec1fd49e30031ee65d5582ebcd9aa6c8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->