### PR TITLE
feat: update autoscaler Lambda runtime to provided.al2023

### DIFF
--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -42,7 +42,7 @@ resource "aws_lambda_function" "autoscaler" {
   function_name = local.function_name
   role          = aws_iam_role.autoscaler.arn
   handler       = "bootstrap"
-  runtime       = "provided.al2"
+  runtime       = "provided.al2023"
   architectures = [var.autoscaling_configuration.architecture == "amd64" ? "x86_64" : coalesce(var.autoscaling_configuration.architecture, "x86_64")]
   timeout       = var.autoscaling_configuration.timeout != null ? var.autoscaling_configuration.timeout : 30
 


### PR DESCRIPTION
## Summary

- Migrate autoscaler Lambda runtime from `provided.al2` (Amazon Linux 2) to `provided.al2023` (Amazon Linux 2023)
- Amazon Linux 2 reaches end of life June 30, 2025 — this keeps the module on a supported runtime

## Changes

The `provided.al2` runtime in AWS Lambda is deprecated and scheduled for EOL. This PR updates the autoscaler Lambda function to use `provided.al2023`, which is the AWS-recommended successor.

1. **`autoscaler/autoscaler.tf`**: Changed `runtime` from `provided.al2` to `provided.al2023` on the `aws_lambda_function.autoscaler` resource

Closes https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/192