### PR TITLE
fix: disable recursive loop detection on lifecycle manager Lambda

### DIFF
--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -56,7 +56,7 @@ resource "aws_lambda_event_source_mapping" "this" {
 
 resource "aws_lambda_function_recursion_config" "this" {
   function_name  = aws_lambda_function.this.function_name
-  recursive_loop = "Allow"
+  recursive_loop = var.allow_recursive_loop ? "Allow" : "Terminate"
 }
 
 resource "aws_cloudwatch_log_group" "log_group" {

--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -54,6 +54,11 @@ resource "aws_lambda_event_source_mapping" "this" {
   event_source_arn = aws_sqs_queue.this.arn
 }
 
+resource "aws_lambda_function_recursion_config" "this" {
+  function_name  = aws_lambda_function.this.function_name
+  recursive_loop = "Allow"
+}
+
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = "/aws/lambda/${local.name}"
   retention_in_days = var.cloudwatch_log_group_retention

--- a/lifecycle_manager/variables.tf
+++ b/lifecycle_manager/variables.tf
@@ -75,3 +75,16 @@ variable "ipv6_allowed_for_dual_stack" {
   type        = bool
   default     = null
 }
+
+variable "allow_recursive_loop" {
+  description = <<EOF
+  Whether to allow the lifecycle manager Lambda to invoke itself recursively via SQS.
+  The lifecycle manager intentionally re-queues messages to the same SQS queue when a worker
+  is busy and cannot yet be drained. AWS Lambda's recursive loop detection treats this pattern
+  as a runaway loop and will terminate invocations, cutting short the drain retry chain.
+  Defaults to true since the retry pattern is intentional and already bounded (30-retry cap, ~45 min max).
+  See: https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html
+  EOF
+  type        = bool
+  default     = true
+}

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ module "lifecycle_manager" {
   spacelift_vpc_subnet_ids         = var.autoscaling_vpc_subnets
   spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
   spacelift_api_credentials        = var.spacelift_api_credentials
+  allow_recursive_loop             = var.lifecycle_manager_allow_recursive_loop
 }
 
 moved {

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,19 @@ variable "extra_iam_statements" {
   default     = []
 }
 
+variable "lifecycle_manager_allow_recursive_loop" {
+  description = <<EOF
+  Whether to allow the lifecycle manager Lambda to invoke itself recursively via SQS.
+  The lifecycle manager intentionally re-queues messages to the same SQS queue when a worker
+  is busy and cannot yet be drained. AWS Lambda's recursive loop detection treats this pattern
+  as a runaway loop and will terminate invocations, cutting short the drain retry chain.
+  Defaults to true since the retry pattern is intentional and already bounded (30-retry cap, ~45 min max).
+  See: https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html
+  EOF
+  type        = bool
+  default     = true
+}
+
 variable "disable_cloudwatch_agent" {
   description = <<EOF
   If true, the CloudWatch Agent (pre-installed in the AMI) will be stopped and disabled on instance startup.


### PR DESCRIPTION
The lifecycle manager re-queues drain-retry messages to the same SQS queue that triggers it. AWS Lambda's recursive loop detection treats this pattern as a runaway loop and terminates invocations, cutting the drain retry chain short and potentially leaving EC2 instances stuck in `Terminating:Wait`.

The retry logic is intentional and already bounded (30-retry cap, ~45 min max). This PR sets `recursive_loop = "Allow"` on the Lambda function so AWS does not auto-remediate it.

Fixes #199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Lambda invocation behavior in a production lifecycle/termination path by disabling recursive-loop termination; misconfiguration could increase retry churn or masking of runaway loops despite existing retry bounds.
> 
> **Overview**
> Prevents AWS Lambda recursive loop detection from terminating the lifecycle manager’s intentional drain-retry chain by adding an `aws_lambda_function_recursion_config` with `recursive_loop = "Allow"` by default.
> 
> Introduces a new module input (`allow_recursive_loop`) and root variable (`lifecycle_manager_allow_recursive_loop`) to control this behavior, and wires it through `main.tf` so callers can opt back into termination if desired.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2980ecb30e8646892f13c4f5419135d0c6594e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->