### PR TITLE
feat: Add fedramp support - bump version

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.1
+module_version: 5.6.2
 
 tests:
   - name: AMD64-based workerpool


### PR DESCRIPTION
Bumps version to release  FedRAMP support for additional domain.
see [#201](https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/201)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the `module_version` value in Spacelift CI configuration with no runtime/infra logic changes.
> 
> **Overview**
> Bumps the Spacelift CI `module_version` from `5.6.1` to `5.6.2` in `.spacelift/config.yml` to align tests/releases with the new module version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ac6abdd796f6c065c7daee745b8e6986f86fc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->