### PR TITLE
fix(autoscaler): constant plan drift when version is unset

### DIFF
--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -1,21 +1,36 @@
+# When no version is pinned, resolve "latest" to a concrete release tag
+# (e.g. "v2.4.0") via the GitHub API. This gives the null_resource trigger
+# a stable value that only changes when a new release is actually published.
+data "http" "latest_release" {
+  count = var.autoscaling_configuration.version == null && var.autoscaling_configuration.s3_package == null ? 1 : 0
+  url   = "https://api.github.com/repos/spacelift-io/ec2-workerpool-autoscaler/releases/latest"
+
+  request_headers = {
+    Accept = "application/vnd.github+json"
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "Failed to fetch latest autoscaler release from GitHub (HTTP ${self.status_code}). Pin the version explicitly via autoscaling_configuration.version to avoid this dependency."
+    }
+  }
+}
+
 locals {
   download_folder    = var.worker_pool_id # Unique folder name to avoid race conditions when downloading the archive in parallel
   architecture       = coalesce(var.autoscaling_configuration.architecture, "amd64")
   autoscaler_zip     = "${local.download_folder}/ec2-workerpool-autoscaler_linux_${local.architecture}.zip"
   function_name      = "${var.base_name}-ec2-autoscaler"
   use_s3_package     = var.autoscaling_configuration.s3_package != null
-  autoscaler_version = coalesce(var.autoscaling_configuration.version, "latest")
+  autoscaler_version = coalesce(var.autoscaling_configuration.version, try(jsondecode(data.http.latest_release[0].response_body).tag_name, null))
 }
 
 resource "null_resource" "download" {
   count = !local.use_s3_package ? 1 : 0
   triggers = {
-    # Always re-download the archive file if the version is set to "latest" or if the file does not exist
-    keeper = (
-      local.autoscaler_version == "latest" || !fileexists(local.autoscaler_zip)
-      ? timestamp()
-      : local.autoscaler_version
-    )
+    # Re-download when the version changes or the zip file has been deleted.
+    keeper = !fileexists(local.autoscaler_zip) ? timestamp() : local.autoscaler_version
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Description of the change

Version defaulting to "latest" used `timestamp()` as the `null_resource` trigger, forcing a replacement on every plan. Resolve "latest" to a concrete release tag via the GitHub API so the trigger is stable.

When no `version` is pinned (and no `s3_package` is used), a `data "http"` source fetches the latest release tag from GitHub (e.g. `v2.4.0`). This concrete value is used as the trigger instead of `timestamp()`, so the download only re-runs when a new release is actually published — or when the zip file is missing.

A `postcondition` on the data source validates the HTTP status code and provides an actionable error message if the API call fails (rate limiting, network issues), guiding users to pin the version explicitly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a runtime dependency on the GitHub Releases API when `autoscaling_configuration.version` is unset, which can fail due to networking/rate limits and affect plans/applies. Otherwise the change is localized to the download trigger logic to stop constant `null_resource` churn.
> 
> **Overview**
> Fixes constant Terraform plan drift for the autoscaler download by resolving an unset `autoscaling_configuration.version` to a concrete GitHub release tag instead of using a `timestamp()`-based trigger.
> 
> Adds a `data "http"` lookup for the latest release (with a `postcondition` to fail fast on non-200 responses) and updates the `null_resource.download` trigger to only re-run when the resolved version changes or the zip file is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700152bb4805aaa167f3aab184608b6357a142e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->