### PR TITLE
feat: export autoscaler CloudWatch log group name

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.3
+module_version: 5.6.4
 
 tests:
   - name: AMD64-based workerpool

--- a/autoscaler/outputs.tf
+++ b/autoscaler/outputs.tf
@@ -1,0 +1,4 @@
+output "log_group_name" {
+  description = "Name of the CloudWatch log group for the autoscaler Lambda"
+  value       = aws_cloudwatch_log_group.log_group.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "secretsmanager_secret_arn" {
   value       = aws_secretsmanager_secret.this.*.arn
   description = "ARN of the secret in Secrets Manager that holds the encrypted environment variables."
 }
+
+output "autoscaler_log_group_name" {
+  value       = local.autoscaling_enabled ? module.autoscaler[0].log_group_name : null
+  description = "Name of the CloudWatch log group for the autoscaler Lambda. Null when autoscaling is disabled."
+}


### PR DESCRIPTION
## Description of the change

Adds a new `autoscaler_log_group_name` output that exposes the CloudWatch log group name of the autoscaler Lambda. This enables consumers to wire the log group to their log forwarding infrastructure (e.g. Datadog forwarder subscription filters) without reconstructing the name from internal conventions.

Returns `null` when autoscaling is disabled.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Terraform outputs only, with no changes to resource definitions or runtime behavior; only potential impact is consumers relying on the new output when autoscaling is disabled (it returns `null`).
> 
> **Overview**
> Exposes the autoscaler Lambda's CloudWatch log group name via a new root output `autoscaler_log_group_name`, returning `null` when autoscaling is disabled.
> 
> Adds a corresponding `log_group_name` output in the `autoscaler` submodule to surface the underlying `aws_cloudwatch_log_group` name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1199343e79de2ae4fa99af1f42120c7aa9a1d6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->