### PR TITLE
feat: support extra environment variables for autoscaler Lambda

### DIFF
--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -56,7 +56,7 @@ resource "aws_lambda_function" "autoscaler" {
   }
 
   environment {
-    variables = {
+    variables = merge({
       AUTOSCALING_GROUP_ARN         = var.auto_scaling_group_arn
       AUTOSCALING_REGION            = var.aws_region
       SPACELIFT_API_KEY_ID          = var.spacelift_api_credentials.api_key_id
@@ -66,7 +66,7 @@ resource "aws_lambda_function" "autoscaler" {
       AUTOSCALING_MAX_CREATE        = var.autoscaling_configuration.max_create != null ? var.autoscaling_configuration.max_create : 1
       AUTOSCALING_MAX_KILL          = var.autoscaling_configuration.max_terminate != null ? var.autoscaling_configuration.max_terminate : 1
       AUTOSCALING_SCALE_DOWN_DELAY  = var.autoscaling_configuration.scale_down_delay != null ? var.autoscaling_configuration.scale_down_delay : 0
-    }
+    }, var.extra_env)
   }
 
   tracing_config {

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -98,3 +98,9 @@ variable "ipv6_allowed_for_dual_stack" {
   type        = bool
   default     = null
 }
+
+variable "extra_env" {
+  description = "Additional environment variables to pass to the autoscaler Lambda function."
+  type        = map(string)
+  default     = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "autoscaler" {
   spacelift_vpc_subnet_ids         = var.autoscaling_vpc_subnets
   spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
   tracing_mode                     = var.autoscaling_tracing_mode
+  extra_env                        = var.autoscaler_extra_env
 }
 
 module "lifecycle_manager" {

--- a/variables.tf
+++ b/variables.tf
@@ -325,6 +325,12 @@ variable "autoscaling_configuration" {
   default = null
 }
 
+variable "autoscaler_extra_env" {
+  description = "Additional environment variables to pass to the autoscaler Lambda function. Values override defaults if keys conflict."
+  type        = map(string)
+  default     = {}
+}
+
 variable "autoscaling_vpc_subnets" {
   description = "List of VPC subnets to use for the autoscaler Lambda function."
   type        = list(string)


### PR DESCRIPTION
## Description of the change

The autoscaler Lambda environment is currently limited to a fixed set of variables. This adds an `autoscaler_extra_env` variable (`map(string)`, default `{}`) that lets users pass arbitrary environment variables to the Lambda function.

This increases flexibility for several use cases: configuring new autoscaler features without waiting for a module release, tuning SDK behavior (e.g. AWS SDK, OpenTelemetry), passing observability configuration (e.g. Datadog), or running custom autoscaler builds.

Extra variables are merged on top of the defaults via `merge()`, so user values take precedence on key conflict.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;