### PR TITLE
feat!: manage worker CloudWatch Log Groups

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,16 @@
+# Log group names are hardcoded to match the awslogs agent configuration in the
+# Spacelift worker AMI (https://github.com/spacelift-io/spacelift-worker-image).
+
+locals {
+  log_groups = toset(["spacelift-info.log", "spacelift-errors.log"])
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  for_each = local.log_groups
+
+  name              = each.key
+  retention_in_days = var.cloudwatch_log_group_retention
+  kms_key_id        = var.cloudwatch_kms_key_id
+  log_group_class   = var.cloudwatch_log_group_class
+  tags              = var.additional_tags
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -2,7 +2,7 @@
 # Spacelift worker AMI (https://github.com/spacelift-io/spacelift-worker-image).
 
 locals {
-  log_groups = toset(["spacelift-info.log", "spacelift-errors.log"])
+  log_groups = var.manage_log_groups ? toset(["spacelift-info.log", "spacelift-errors.log"]) : []
 }
 
 resource "aws_cloudwatch_log_group" "this" {

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -64,6 +64,8 @@ module "this" {
   vpc_subnets     = data.aws_subnets.this.ids
   worker_pool_id  = random_string.worker_pool_id.id
 
+  manage_log_groups = false
+
   tag_specifications = [
     {
       resource_type = "instance"

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -59,7 +59,8 @@ module "this" {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
-  ami_architecture = "arm64"
+  manage_log_groups = false
+  ami_architecture  = "arm64"
   # t4g.micro is just for using the random provider and a few resources.
   # If you are using more than a few resources as well as memory intensive providers it's recommended to use a t4g.medium or at least a t4g.small
   # https://docs.spacelift.io/concepts/worker-pools#hardware-recommendations

--- a/examples/autoscaler-custom-ebs-throughput/main.tf
+++ b/examples/autoscaler-custom-ebs-throughput/main.tf
@@ -89,5 +89,6 @@ module "this" {
     triggers = ["tag"]
   }
 
+  manage_log_groups = false
   volume_throughput = 250
 }

--- a/examples/autoscaler-custom-s3-package/main.tf
+++ b/examples/autoscaler-custom-s3-package/main.tf
@@ -68,6 +68,7 @@ module "this" {
     }
   }
 
+  manage_log_groups = false
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
     api_key_id       = var.spacelift_api_key_id

--- a/examples/autoscaler/main.tf
+++ b/examples/autoscaler/main.tf
@@ -79,6 +79,8 @@ module "this" {
     api_key_secret   = var.spacelift_api_key_secret
   }
 
+  manage_log_groups = false
+
   instance_refresh = {
     strategy = "Rolling"
     preferences = {

--- a/examples/byo-ssm-secretsmanager-with-autoscaling-and-lifecycle/main.tf
+++ b/examples/byo-ssm-secretsmanager-with-autoscaling-and-lifecycle/main.tf
@@ -116,4 +116,6 @@ module "this" {
     }
     triggers = ["tag"]
   }
+
+  manage_log_groups = false
 }

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -90,4 +90,5 @@ module "this" {
   security_groups      = [data.aws_security_group.this.id]
   vpc_subnets          = data.aws_subnets.this.ids
   worker_pool_id       = random_string.worker_pool_id.id
+  manage_log_groups    = false
 }

--- a/examples/extra-iam-statements/main.tf
+++ b/examples/extra-iam-statements/main.tf
@@ -66,6 +66,7 @@ module "this" {
   extra_iam_statements = [
     data.aws_iam_policy_document.extra.json,
   ]
+  manage_log_groups = false
 }
 
 data "aws_iam_policy_document" "extra" {

--- a/examples/self-hosted-vpc-autoscaler/main.tf
+++ b/examples/self-hosted-vpc-autoscaler/main.tf
@@ -106,4 +106,5 @@ EOT
     ]
     power_off_on_error = true
   }
+  manage_log_groups = false
 }

--- a/examples/self-hosted/main.tf
+++ b/examples/self-hosted/main.tf
@@ -82,4 +82,5 @@ EOT
     ]
     power_off_on_error = true
   }
+  manage_log_groups = false
 }

--- a/examples/spot-instances/main.tf
+++ b/examples/spot-instances/main.tf
@@ -64,4 +64,5 @@ module "this" {
   instance_market_options = {
     market_type = "spot"
   }
+  manage_log_groups = false
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,8 @@ output "autoscaler_log_group_name" {
   value       = local.autoscaling_enabled ? module.autoscaler[0].log_group_name : null
   description = "Name of the CloudWatch log group for the autoscaler Lambda. Null when autoscaling is disabled."
 }
+
+output "log_group_arns" {
+  description = "Map of worker CloudWatch Log Group names to their ARNs."
+  value       = { for name, lg in aws_cloudwatch_log_group.this : name => lg.arn }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -433,3 +433,9 @@ variable "disable_cloudwatch_agent" {
   type        = bool
   default     = false
 }
+
+variable "manage_log_groups" {
+  description = "Whether to manage the CloudWatch Log Group for the worker instances. If false, the log group must be managed by the caller."
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -396,9 +396,21 @@ variable "spacelift_api_credentials" {
 }
 
 variable "cloudwatch_log_group_retention" {
-  description = "Retention period for the autoscaler and lifecycle manager cloudwatch log group."
+  description = "Retention period for the autoscaler, lifecycle manager, and worker CloudWatch Log Groups."
   type        = number
-  default     = 7
+  default     = 60
+}
+
+variable "cloudwatch_kms_key_id" {
+  description = "ARN of the KMS Key to use for encrypting CloudWatch Log Groups."
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_log_group_class" {
+  description = "The log class of the CloudWatch Log Groups."
+  type        = string
+  default     = null
 }
 
 variable "extra_iam_statements" {


### PR DESCRIPTION
This picks up #190 which I'd like to get across the line.

The Spacelift Worker AMI creates `spacelift-info.log` and `spacelift-errors.log` on first boot, but this module has never managed them. Every new deployment silently creates unmanaged log groups with no retention policy and no visibility in Terraform state.

I'm sure that every consumer of this module eventually notices after a year or two when their storage costs are weirdly high. And then they are forced to make a clickops change to deal with the problem 🫠 

As discussed in the previous PR there's no backwards-compatible fix for this problem. So this change will require existing users to perform a manual step as part of their module upgrade.

IMO, the benefit to all new Spacelift customers is well worth this minor pain. The longer you wait, the more the pain grows.

## Migration

Update your module to this new version. Apply will fail because the two CloudWatch logs already exist. Then run the following imports as a Spacelift task:

```
terraform import 'module.<name>.aws_cloudwatch_log_group.this["spacelift-info.log"]' spacelift-info.log
terraform import 'module.<name>.aws_cloudwatch_log_group.this["spacelift-errors.log"]' spacelift-errors.log
```

## Changes

- Manage `spacelift-info.log` and `spacelift-errors.log` log groups
- New variable: `cloudwatch_kms_key_id` — KMS key for log group encryption
- New variable: `cloudwatch_log_group_class` — STANDARD or INFREQUENT_ACCESS
- New output: `log_group_arns`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Terraform-managed CloudWatch Log Groups that will conflict with pre-existing worker-created log groups in existing deployments, requiring imports during upgrade. Also changes the default log retention from 7 to 60 days and introduces optional KMS encryption/log class settings, impacting logging cost and configuration.
> 
> **Overview**
> This PR begins managing the Spacelift worker CloudWatch Log Groups (`spacelift-info.log` and `spacelift-errors.log`) in Terraform, applying retention, optional KMS encryption, and log class settings.
> 
> It updates `cloudwatch_log_group_retention` (description + default from 7 to 60 days), adds new variables `cloudwatch_kms_key_id` and `cloudwatch_log_group_class`, and exposes a new `log_group_arns` output mapping log group names to ARNs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee773b06db5135d83eee19b1ccc9ff4493db29e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->