### PR TITLE
feat: support extra environment variables - bump version

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.4
+module_version: 5.6.5
 
 tests:
   - name: AMD64-based workerpool


### PR DESCRIPTION
Bumps version to release autoscaler_extra_env support.
See [#206](https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/pull/206)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only version bump; no infrastructure logic or runtime behavior changes are introduced in this PR.
> 
> **Overview**
> Bumps the Spacelift test config `module_version` from `5.6.4` to `5.6.5` in `.spacelift/config.yml` to reflect the new module release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c8386632f81558cf18a5e03e923a808f4fcca9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->