### PR TITLE
feat: reorder example inputs for consistency and bump module version to 5.6.5

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.4
+module_version: 5.6.5
 
 tests:
   - name: AMD64-based workerpool

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -52,6 +52,8 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   configuration = <<-EOT
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
     export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
@@ -60,9 +62,9 @@ module "this" {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
   manage_log_groups = false
 

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -52,6 +52,8 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   configuration = <<-EOT
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
   EOT
@@ -59,13 +61,15 @@ module "this" {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
-  manage_log_groups = false
-  ami_architecture  = "arm64"
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+
+  ami_architecture = "arm64"
   # t4g.micro is just for using the random provider and a few resources.
   # If you are using more than a few resources as well as memory intensive providers it's recommended to use a t4g.medium or at least a t4g.small
   # https://docs.spacelift.io/concepts/worker-pools#hardware-recommendations
   ec2_instance_type = "t4g.micro"
-  security_groups   = [data.aws_security_group.this.id]
-  vpc_subnets       = data.aws_subnets.this.ids
-  worker_pool_id    = random_string.worker_pool_id.id
+
+  manage_log_groups = false
 }

--- a/examples/autoscaler-custom-ebs-throughput/main.tf
+++ b/examples/autoscaler-custom-ebs-throughput/main.tf
@@ -52,18 +52,20 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
-  # Autoscaler VPC configuration
+  volume_throughput = 250
+
   autoscaling_vpc_sg_ids  = [data.aws_security_group.this.id]
   autoscaling_vpc_subnets = data.aws_subnets.this.ids
-
   autoscaling_configuration = {
     max_create          = 5
     max_terminate       = 5
@@ -72,7 +74,6 @@ module "this" {
     timeout             = 60
     scale_down_delay    = 5
   }
-
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
     api_key_id       = var.spacelift_api_key_id
@@ -90,5 +91,4 @@ module "this" {
   }
 
   manage_log_groups = false
-  volume_throughput = 250
 }

--- a/examples/autoscaler-custom-s3-package/main.tf
+++ b/examples/autoscaler-custom-s3-package/main.tf
@@ -52,13 +52,15 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
   autoscaling_configuration = {
     version = var.autoscaler_version
@@ -67,11 +69,11 @@ module "this" {
       key    = aws_s3_object.autoscaler_binary.key
     }
   }
-
-  manage_log_groups = false
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
     api_key_id       = var.spacelift_api_key_id
     api_key_secret   = var.spacelift_api_key_secret
   }
+
+  manage_log_groups = false
 }

--- a/examples/autoscaler/main.tf
+++ b/examples/autoscaler/main.tf
@@ -52,18 +52,18 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
-  # Autoscaler VPC configuration
   autoscaling_vpc_sg_ids  = [data.aws_security_group.this.id]
   autoscaling_vpc_subnets = data.aws_subnets.this.ids
-
   autoscaling_configuration = {
     max_create          = 5
     max_terminate       = 5
@@ -72,14 +72,11 @@ module "this" {
     timeout             = 60
     scale_down_delay    = 5
   }
-
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
     api_key_id       = var.spacelift_api_key_id
     api_key_secret   = var.spacelift_api_key_secret
   }
-
-  manage_log_groups = false
 
   instance_refresh = {
     strategy = "Rolling"
@@ -90,4 +87,6 @@ module "this" {
     }
     triggers = ["tag"]
   }
+
+  manage_log_groups = false
 }

--- a/examples/byo-ssm-secretsmanager-with-autoscaling-and-lifecycle/main.tf
+++ b/examples/byo-ssm-secretsmanager-with-autoscaling-and-lifecycle/main.tf
@@ -76,9 +76,7 @@ resource "aws_ssm_parameter" "byo" {
 module "this" {
   source = "../../"
 
-  security_groups = [data.aws_security_group.this.id]
-  vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
+  worker_pool_id = random_string.worker_pool_id.id
 
   byo_secretsmanager = {
     name = aws_secretsmanager_secret.byo.name
@@ -88,11 +86,13 @@ module "this" {
       "SPACELIFT_POOL_PRIVATE_KEY"
     ]
   }
-
   byo_ssm = {
     name = aws_ssm_parameter.byo.name
     arn  = aws_ssm_parameter.byo.arn
   }
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
 
   autoscaling_configuration = {
     max_create          = 5
@@ -101,7 +101,6 @@ module "this" {
     schedule_expression = "rate(1 minute)"
     timeout             = 60
   }
-
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
     api_key_id       = var.spacelift_api_key_id

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -81,14 +81,18 @@ resource "aws_iam_role_policy_attachment" "attachment" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+
   create_iam_role      = false
   custom_iam_role_name = aws_iam_role.this.name
-  security_groups      = [data.aws_security_group.this.id]
-  vpc_subnets          = data.aws_subnets.this.ids
-  worker_pool_id       = random_string.worker_pool_id.id
-  manage_log_groups    = false
+
+  manage_log_groups = false
 }

--- a/examples/extra-iam-statements/main.tf
+++ b/examples/extra-iam-statements/main.tf
@@ -52,6 +52,8 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   configuration = <<-EOT
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
     export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
@@ -60,12 +62,14 @@ module "this" {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
+
   extra_iam_statements = [
     data.aws_iam_policy_document.extra.json,
   ]
+
   manage_log_groups = false
 }
 

--- a/examples/self-hosted-vpc-autoscaler/main.tf
+++ b/examples/self-hosted-vpc-autoscaler/main.tf
@@ -52,36 +52,27 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
   autoscaling_vpc_sg_ids  = [data.aws_security_group.this.id]
   autoscaling_vpc_subnets = data.aws_subnets.this.ids
-
   autoscaling_configuration = {
     max_create       = 2
     max_terminate    = 2
     scale_down_delay = 5 # minutes
   }
-  instance_refresh = {
-    strategy = "Rolling"
-    preferences = {
-      instance_warmup        = 60
-      min_healthy_percentage = 50
-      max_healthy_percentage = 100
-    }
-    triggers = ["tag"]
-  }
-
   spacelift_api_credentials = {
     api_key_endpoint = var.spacelift_api_key_endpoint
-    api_key_secret   = var.spacelift_api_key_secret
     api_key_id       = var.spacelift_api_key_id
+    api_key_secret   = var.spacelift_api_key_secret
   }
 
   selfhosted_configuration = {
@@ -106,5 +97,16 @@ EOT
     ]
     power_off_on_error = true
   }
+
+  instance_refresh = {
+    strategy = "Rolling"
+    preferences = {
+      instance_warmup        = 60
+      min_healthy_percentage = 50
+      max_healthy_percentage = 100
+    }
+    triggers = ["tag"]
+  }
+
   manage_log_groups = false
 }

--- a/examples/self-hosted/main.tf
+++ b/examples/self-hosted/main.tf
@@ -52,13 +52,15 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
   selfhosted_configuration = {
     s3_uri                         = "s3://example-bucketname1234/spacelift-launcher"
@@ -82,5 +84,6 @@ EOT
     ]
     power_off_on_error = true
   }
+
   manage_log_groups = false
 }

--- a/examples/spot-instances/main.tf
+++ b/examples/spot-instances/main.tf
@@ -52,17 +52,19 @@ resource "random_string" "worker_pool_id" {
 module "this" {
   source = "../../"
 
+  worker_pool_id = random_string.worker_pool_id.id
+
   secure_env_vars = {
     SPACELIFT_TOKEN            = "<token-here>"
     SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
   }
+
   security_groups = [data.aws_security_group.this.id]
   vpc_subnets     = data.aws_subnets.this.ids
-  worker_pool_id  = random_string.worker_pool_id.id
 
-  # Enable spot instances
   instance_market_options = {
     market_type = "spot"
   }
+
   manage_log_groups = false
 }


### PR DESCRIPTION
## Summary

- Reorder module inputs across all examples to follow a consistent, logical pattern
- Bump module version from 5.6.4 to 5.6.5

## Changes

Standardizes the input ordering across all 11 example `main.tf` files to follow a consistent pattern:

1. **`worker_pool_id`** — moved to the top of the module block (right after `source`) since it's the primary identifier
2. **Configuration/credentials** — `configuration`, `secure_env_vars`, `byo_ssm`, `byo_secretsmanager` grouped together
3. **Networking** — `security_groups` and `vpc_subnets` grouped together
4. **Feature-specific inputs** — architecture, instance type, autoscaler config, spot config, etc.
5. **Lifecycle/optional** — `instance_refresh`, `manage_log_groups` placed last

Also adds consistent blank lines between logical groups for readability.

The version bump in `.spacelift/config.yml` reflects this release (5.6.4 → 5.6.5).