### PR TITLE
fix(autoscaler): download.sh permission denied

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.5
+module_version: 5.6.6
 
 tests:
   - name: AMD64-based workerpool

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -19,7 +19,7 @@ resource "null_resource" "download" {
   }
 
   provisioner "local-exec" {
-    command = "${path.module}/download.sh ${local.autoscaler_version} ${local.architecture} ${local.download_folder}"
+    command = "chmod +x ${path.module}/download.sh && ${path.module}/download.sh ${local.autoscaler_version} ${local.architecture} ${local.download_folder}"
   }
 }
 


### PR DESCRIPTION
## Description of the change

`download.sh` fails with "Permission denied" on the Spacelift runner — the file has 644 instead of the 755 stored in git.

Not sure why this started failing — it worked before. We bumped the workerpool module (4.4.3 → 5.6.4) and AWS provider (~>5.0 → ~>6.0), keeping the same OpenTofu version across runs.

[CU-869cv4aug](https://app.clickup.com/t/869cv4aug)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [x] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;