### PR TITLE
fix: graceful shutdown when ASG terminates an instance

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 5.6.5
+module_version: 6.0.0
 
 tests:
   - name: AMD64-based workerpool

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-spacelift () {(
+setup() {
   set -e
 
   %{ if disable_cloudwatch_agent ~}
@@ -31,7 +31,7 @@ spacelift () {(
       fi
     fi
   fi
-  
+
   baseURL="https://downloads.${domain_name}/spacelift-launcher$fedrampSuffix"
   binaryURL=$(printf "%s-%s" "$baseURL" "$currentArch")
   shaSumURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS")
@@ -93,13 +93,40 @@ spacelift () {(
   export SPACELIFT_METADATA_asg_id=$(aws autoscaling --region=${region} describe-auto-scaling-instances --instance-ids $SPACELIFT_METADATA_instance_id | jq -r '.AutoScalingInstances[0].AutoScalingGroupName')
   validate_metadata "$SPACELIFT_METADATA_asg_id" "asg_id" || return 1
 
-  echo "Starting the Spacelift binary" >> /var/log/spacelift/info.log
-  /usr/bin/spacelift-launcher 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
-)}
+  # Write environment file for the systemd service.
+  # Dump the full environment so the launcher inherits everything the setup
+  # function exported, including non-SPACELIFT_ vars that users may set via
+  # var.configuration (e.g. HTTP_PROXY, ADDITIONAL_ROOT_CAS).
+  mkdir -p /etc/spacelift
+  env > /etc/spacelift/env
+  chmod 600 /etc/spacelift/env
 
-# Reset the errexit option so if for some reason the `spacelift` binary stops, the poweroff should be run.
-set +e
-spacelift
-echo "Powering off in ${poweroff_delay} seconds" >> /var/log/spacelift/error.log
-sleep ${poweroff_delay}
-poweroff
+  # Create systemd service unit
+  cat > /etc/systemd/system/spacelift-launcher.service <<UNIT
+[Unit]
+Description=Spacelift Launcher
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/spacelift/env
+ExecStart=/usr/bin/spacelift-launcher
+ExecStopPost=/bin/sh -c 'sleep ${poweroff_delay} && poweroff'
+KillMode=control-group
+TimeoutStopSec=30
+StandardOutput=append:/var/log/spacelift/info.log
+StandardError=append:/var/log/spacelift/error.log
+Restart=no
+UNIT
+
+  systemctl daemon-reload
+  systemctl start spacelift-launcher
+  echo "Spacelift launcher started as systemd service" >> /var/log/spacelift/info.log
+}
+
+if ! setup; then
+  echo "Setup failed, powering off in ${poweroff_delay} seconds" >> /var/log/spacelift/error.log
+  sleep ${poweroff_delay}
+  poweroff
+fi


### PR DESCRIPTION
## Description of the change

The autoscaler terminates instances via the EC2 API. During these terminations, the launcher never received SIGTERM. This caused no problems, as the workers were already drained. However, the workers still crashed and MQTT last will was fired.

EC2 terminate API call sends an ACPI power button press. Systemd begins graceful shutdown, but cloud-init script is not part of that. The cloud-init script never gets a SIGTERM as part of the shutdown. So the machine just hangs until it gets forcefully terminated.

Run the launcher as a systemd service instead. The user-data script handles setup (download, verify, metadata), writes an environment file, starts the service, and exits. Cloud-init completes normally. ExecStopPost preserves the poweroff safety net.

I tested the new script on a private worker pool, with the changes worker.gone trace shows crashed=false.

[CU-869czj37u](https://app.clickup.com/t/869czj37u)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;