### PR TITLE
fix: graceful shutdown when ASG terminates an instance - Self-hosted

### DIFF
--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -157,7 +157,7 @@ User=spacelift
 %{ endif ~}
 ExecStart=/opt/spacelift/run-launcher.sh
 %{ if power_off_on_error ~}
-ExecStopPost=/bin/sh -c 'sleep 15 && poweroff'
+ExecStopPost=+/bin/sh -c 'sleep 15 && poweroff'
 %{ endif ~}
 KillMode=control-group
 TimeoutStopSec=30

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -142,14 +142,33 @@ EOF
 
 run_spacelift () {(
   set -e
-  echo "Starting run-launcher.sh script" >> /var/log/spacelift/info.log
-  if [[ "${run_launcher_as_spacelift_user}" == "false" ]]; then
-    echo "Running the launcher as root" >> /var/log/spacelift/info.log
-    /opt/spacelift/run-launcher.sh 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
-  else
-    echo "Running the launcher as spacelift (UID 1983)" >> /var/log/spacelift/info.log
-    runuser -l spacelift -c '/opt/spacelift/run-launcher.sh' 1>>/var/log/spacelift/info.log 2>>/var/log/spacelift/error.log
-  fi
+  echo "Setting up Spacelift launcher systemd service" >> /var/log/spacelift/info.log
+
+  cat > /etc/systemd/system/spacelift-launcher.service <<UNIT
+[Unit]
+Description=Spacelift Launcher
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+%{ if run_launcher_as_spacelift_user ~}
+User=spacelift
+%{ endif ~}
+ExecStart=/opt/spacelift/run-launcher.sh
+%{ if power_off_on_error ~}
+ExecStopPost=/bin/sh -c 'sleep 15 && poweroff'
+%{ endif ~}
+KillMode=control-group
+TimeoutStopSec=30
+StandardOutput=append:/var/log/spacelift/info.log
+StandardError=append:/var/log/spacelift/error.log
+Restart=no
+UNIT
+
+  systemctl daemon-reload
+  systemctl start spacelift-launcher
+  echo "Spacelift launcher started as systemd service" >> /var/log/spacelift/info.log
 )}
 
 disable_cloudwatch_agent
@@ -158,10 +177,11 @@ download_launcher
 configure_docker
 load_custom_ca_certs
 create_spacelift_launcher_script
-run_spacelift
 
-if [[ "${power_off_on_error}" == "true" ]]; then
-  echo "Powering off in 15 seconds" >> /var/log/spacelift/error.log
+if ! run_spacelift; then
+  echo "Failed to start Spacelift launcher service, powering off in 15 seconds" >> /var/log/spacelift/error.log
+  %{ if power_off_on_error ~}
   sleep 15
   poweroff
+  %{ endif ~}
 fi


### PR DESCRIPTION
## Description of the change

The autoscaler terminates instances via the EC2 API. During these terminations, the launcher never received SIGTERM. This caused no problems, as the workers were already drained. However, the workers still crashed and MQTT last will was fired.

EC2 terminate API call sends an ACPI power button press. Systemd begins graceful shutdown, but cloud-init script is not part of that. The cloud-init script never gets a SIGTERM as part of the shutdown. So the machine just hangs until it gets forcefully terminated.

Run the launcher as a systemd service instead. The user-data script handles setup (download, verify, metadata), writes an environment file, starts the service, and exits. Cloud-init completes normally. ExecStopPost preserves the poweroff safety net.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
