### PR TITLE
fix: autoscaling_configuration validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -325,7 +325,7 @@ variable "autoscaling_configuration" {
   default = null
 
   validation {
-    condition     = var.autoscaling_configuration == null || var.autoscaling_configuration.version == "latest" || startswith(var.autoscaling_configuration.version, "v")
+    condition     = var.autoscaling_configuration == null || try(var.autoscaling_configuration.version == "latest" || startswith(var.autoscaling_configuration.version, "v"), false)
     error_message = "version must be a release tag starting with \"v\" (e.g. \"v2.5.0\"), or \"latest\"."
   }
 }


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a Terraform variable validation expression (plus a newline), but it could change when invalid inputs are caught during plan/apply for edge cases with unknown values.
> 
> **Overview**
> Tightens the `autoscaling_configuration` variable validation by wrapping the `version` checks in `try(..., false)`, preventing evaluation errors when the value is missing/unknown while still enforcing `latest` or `v*` tags.
> 
> Also fixes `variables.tf` to end with a newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f813156f177bd7bf4b3d8f1cbeb66d07356eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->