### PR TITLE
Uses same condition as http data source to gate ref to the data source

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 6.0.1
+module_version: 6.0.3
 
 tests:
   - name: AMD64-based workerpool

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -5,7 +5,7 @@ locals {
   function_name      = "${var.base_name}-ec2-autoscaler"
   use_s3_package     = var.autoscaling_configuration.s3_package != null
   resolve_latest     = var.autoscaling_configuration.version == "latest"
-  autoscaler_version = local.resolve_latest ? jsondecode(data.http.latest_release[0].response_body).tag_name : var.autoscaling_configuration.version
+  autoscaler_version = !local.use_s3_package && local.resolve_latest ? jsondecode(data.http.latest_release[0].response_body).tag_name : var.autoscaling_configuration.version
 }
 
 # When version = "latest", resolve to a concrete release tag via the GitHub API.


### PR DESCRIPTION
## Description of the change

When using an `s3_package`, the http data source for getting the latest version is not used. However, the ref to the data source was not gated on the `s3_package` input, so it generated an error.

Fixes https://github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2/issues/216

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue);
- [ ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional change to prevent referencing an unused `data.http.latest_release` when `s3_package` is set, plus a module version bump.
> 
> **Overview**
> Fixes autoscaler version resolution so the `latest` GitHub release lookup is only referenced when *not* using an `s3_package`, matching the existing `data.http.latest_release` `count` guard and avoiding plan-time errors.
> 
> Bumps `.spacelift/config.yml` `module_version` from `6.0.1` to `6.0.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9d9eba964351cce21ebd9212dc5b78056fc70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->