### PR TITLE
(ADD) Support to pull certificates from S3 bucket

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 6.0.3
+module_version: 6.1.0
 
 tests:
   - name: AMD64-based workerpool

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 6.1.0
+module_version: 6.2.0
 
 tests:
   - name: AMD64-based workerpool

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 6.3.0
+module_version: 6.1.0
 
 tests:
   - name: AMD64-based workerpool

--- a/asg.tf
+++ b/asg.tf
@@ -8,10 +8,13 @@ locals {
     http_proxy_config              = var.selfhosted_configuration.http_proxy_config == null ? "" : var.selfhosted_configuration.http_proxy_config
     https_proxy_config             = var.selfhosted_configuration.https_proxy_config == null ? "" : var.selfhosted_configuration.https_proxy_config
     no_proxy_config                = var.selfhosted_configuration.no_proxy_config == null ? "" : var.selfhosted_configuration.no_proxy_config
-    ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
+    ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
+    s3_bucket_name                 = var.selfhosted_configuration.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
+    s3_object_key                  = var.selfhosted_configuration.s3_object_key == null ? "" : var.selfhosted_configuration.s3_object_key
+    load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {

--- a/asg.tf
+++ b/asg.tf
@@ -14,7 +14,7 @@ locals {
     ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
     s3_bucket_name                 = var.selfhosted_configuration.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
     s3_object_key                  = var.selfhosted_configuration.s3_object_key == null ? "" : var.selfhosted_configuration.s3_object_key
-    load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
+    load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? false : var.selfhosted_configuration.load_custom_certs
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {

--- a/asg.tf
+++ b/asg.tf
@@ -11,6 +11,7 @@ locals {
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
+    ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
     s3_bucket_name                 = var.selfhosted_configuration.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
     s3_object_key                  = var.selfhosted_configuration.s3_object_key == null ? "" : var.selfhosted_configuration.s3_object_key
     load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs

--- a/asg.tf
+++ b/asg.tf
@@ -12,6 +12,9 @@ locals {
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
+    s3_bucket_name                 = var.s3_bucket_name
+    s3_object_key                  = var.s3_object_key
+    load_custom_certs              = var.load_custom_certs
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {

--- a/asg.tf
+++ b/asg.tf
@@ -12,7 +12,7 @@ locals {
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
     s3_bucket_name                 = var.selfhosted_configuration.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
-    s3_object_key                  = var.selfhosted_configuration.s3_object_key  == null ? "" : var.selfhosted_configuration.s3_object_key
+    s3_object_key                  = var.selfhosted_configuration.s3_object_key == null ? "" : var.selfhosted_configuration.s3_object_key
     load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
   })
 

--- a/asg.tf
+++ b/asg.tf
@@ -8,13 +8,12 @@ locals {
     http_proxy_config              = var.selfhosted_configuration.http_proxy_config == null ? "" : var.selfhosted_configuration.http_proxy_config
     https_proxy_config             = var.selfhosted_configuration.https_proxy_config == null ? "" : var.selfhosted_configuration.https_proxy_config
     no_proxy_config                = var.selfhosted_configuration.no_proxy_config == null ? "" : var.selfhosted_configuration.no_proxy_config
-    ca_certificates                = var.selfhosted_configuration.ca_certificates == null ? [] : var.selfhosted_configuration.ca_certificates
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
-    s3_bucket_name                 = var.s3_bucket_name
-    s3_object_key                  = var.s3_object_key
-    load_custom_certs              = var.load_custom_certs
+    s3_bucket_name                 = var.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
+    s3_object_key                  = var.s3_object_key  == null ? "" : var.selfhosted_configuration.s3_object_key
+    load_custom_certs              = var.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {

--- a/asg.tf
+++ b/asg.tf
@@ -11,9 +11,9 @@ locals {
     region                         = data.aws_region.this.region
     power_off_on_error             = var.selfhosted_configuration.power_off_on_error == null ? true : var.selfhosted_configuration.power_off_on_error
     disable_cloudwatch_agent       = var.disable_cloudwatch_agent
-    s3_bucket_name                 = var.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
-    s3_object_key                  = var.s3_object_key  == null ? "" : var.selfhosted_configuration.s3_object_key
-    load_custom_certs              = var.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
+    s3_bucket_name                 = var.selfhosted_configuration.s3_bucket_name == null ? "" : var.selfhosted_configuration.s3_bucket_name
+    s3_object_key                  = var.selfhosted_configuration.s3_object_key  == null ? "" : var.selfhosted_configuration.s3_object_key
+    load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {

--- a/iam.tf
+++ b/iam.tf
@@ -154,3 +154,32 @@ resource "aws_iam_role_policy" "extra" {
   role   = aws_iam_role.this[0].name
   policy = data.aws_iam_policy_document.extra[0].json
 }
+
+resource "aws_iam_policy" "ca_bundle_access" {
+  count       = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+  name        = "${local.base_name}-CustomCABundleReadAccess"
+  description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
+  policy      = data.aws_iam_policy_document.worker_ca[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {
+  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.ca_bundle_access[0].arn
+}
+
+data "aws_iam_policy_document" "worker_ca" {
+  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+
+  statement {
+    sid    = "AllowReadCustomCABundle"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.selfhosted_configuration.s3_bucket_name}/${var.selfhosted_configuration.s3_object_key}"
+    ]
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -159,7 +159,7 @@ resource "aws_iam_policy" "ca_bundle_access" {
   count       = var.selfhosted_configuration.load_custom_certs ? 1 : 0
   name        = "CustomCABundleReadAccess-${random_string.iam_suffix.result}"
   description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
-  policy      = data.aws_iam_policy_document.worker_ca.json
+  policy      = data.aws_iam_policy_document.worker_ca[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {

--- a/iam.tf
+++ b/iam.tf
@@ -157,7 +157,7 @@ resource "aws_iam_role_policy" "extra" {
 
 resource "aws_iam_policy" "ca_bundle_access" {
   count       = var.selfhosted_configuration.load_custom_certs ? 1 : 0
-  name        = "CustomCABundleReadAccess-${random_string.iam_suffix.result}"
+  name        = "${local.base_name}-CustomCABundleReadAccess"
   description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
   policy      = data.aws_iam_policy_document.worker_ca[0].json
 }

--- a/iam.tf
+++ b/iam.tf
@@ -154,3 +154,30 @@ resource "aws_iam_role_policy" "extra" {
   role   = aws_iam_role.this[0].name
   policy = data.aws_iam_policy_document.extra[0].json
 }
+
+resource "aws_iam_policy" "ca_bundle_access" {
+  count = var.load_custom_certs ? 1 : 0
+  name        = "CustomCABundleReadAccess-${random_string.iam_suffix.result}"
+  description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
+  policy      = data.aws_iam_policy_document.worker_ca.json
+}
+
+resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {
+  count = var.load_custom_certs ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.ca_bundle_access[0].arn
+}
+
+data "aws_iam_policy_document" "worker_ca" {
+  statement {
+    sid    = "AllowReadCustomCABundle"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.s3_bucket_name}/${var.s3_object_key}"
+    ]
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -156,22 +156,20 @@ resource "aws_iam_role_policy" "extra" {
 }
 
 resource "aws_iam_policy" "ca_bundle_access" {
-  count       = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+  count       = coalesce(var.selfhosted_configuration.load_custom_certs, false) ? 1 : 0
   name        = "${local.base_name}-CustomCABundleReadAccess"
   description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
   policy      = data.aws_iam_policy_document.worker_ca[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {
-  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
-
+  count      = coalesce(var.selfhosted_configuration.load_custom_certs, false) ? 1 : 0
   role       = aws_iam_role.this[0].name
   policy_arn = aws_iam_policy.ca_bundle_access[0].arn
 }
 
 data "aws_iam_policy_document" "worker_ca" {
-  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
-
+  count = coalesce(var.selfhosted_configuration.load_custom_certs, false) ? 1 : 0
   statement {
     sid    = "AllowReadCustomCABundle"
     effect = "Allow"

--- a/iam.tf
+++ b/iam.tf
@@ -156,14 +156,14 @@ resource "aws_iam_role_policy" "extra" {
 }
 
 resource "aws_iam_policy" "ca_bundle_access" {
-  count = var.load_custom_certs ? 1 : 0
+  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
   name        = "CustomCABundleReadAccess-${random_string.iam_suffix.result}"
   description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
   policy      = data.aws_iam_policy_document.worker_ca.json
 }
 
 resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {
-  count = var.load_custom_certs ? 1 : 0
+  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
 
   role       = aws_iam_role.this[0].name
   policy_arn = aws_iam_policy.ca_bundle_access[0].arn
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "worker_ca" {
       "s3:GetObject"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${var.s3_bucket_name}/${var.s3_object_key}"
+      "arn:${data.aws_partition.current.partition}:s3:::${var.selfhosted_configuration.s3_bucket_name}/${var.selfhosted_configuration.s3_object_key}"
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -156,7 +156,7 @@ resource "aws_iam_role_policy" "extra" {
 }
 
 resource "aws_iam_policy" "ca_bundle_access" {
-  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+  count       = var.selfhosted_configuration.load_custom_certs ? 1 : 0
   name        = "CustomCABundleReadAccess-${random_string.iam_suffix.result}"
   description = "Policy to allow downloading the custom CA bundle from S3 for trust store updates."
   policy      = data.aws_iam_policy_document.worker_ca.json
@@ -170,6 +170,8 @@ resource "aws_iam_role_policy_attachment" "ca_bundle_attach" {
 }
 
 data "aws_iam_policy_document" "worker_ca" {
+  count = var.selfhosted_configuration.load_custom_certs ? 1 : 0
+
   statement {
     sid    = "AllowReadCustomCABundle"
     effect = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -19,15 +19,6 @@ resource "aws_ssm_parameter" "spacelift_api_key_secret" {
   tags  = var.additional_tags
 }
 
-resource "random_string" "iam_suffix" {
-  length           = 4
-  numeric          = true
-  special          = true
-  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
-  lower            = false
-  upper            = false
-}
-
 module "autoscaler" {
   count  = local.autoscaling_enabled ? 1 : 0
   source = "./autoscaler"

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,15 @@ resource "aws_ssm_parameter" "spacelift_api_key_secret" {
   tags  = var.additional_tags
 }
 
+resource "random_string" "iam_suffix" {
+  length           = 4
+  numeric          = true
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
 module "autoscaler" {
   count  = local.autoscaling_enabled ? 1 : 0
   source = "./autoscaler"

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -66,18 +66,48 @@ configure_docker () {(
 
 load_custom_ca_certs () {(
   set -e
+  local certs_installed=false
 
   %{ if length(ca_certificates) > 0 ~}
-  echo "Installing custom root CA certificates" >> /var/log/spacelift/info.log
+  echo "Installing custom root CA certificates from Terraform variables..." >> /var/log/spacelift/info.log
   %{ for cert in ca_certificates ~}
   echo "${cert}" > /etc/pki/ca-trust/source/anchors/$(uuidgen).crt
   %{ endfor ~}
-
-  sudo update-ca-trust
-  echo "Custom root CA certificates are GO" >> /var/log/spacelift/info.log
+  certs_installed=true
+  echo "Successfully installed CA certificates from variables." >> /var/log/spacelift/info.log
   %{ else ~}
-  echo "No CA certificates to install." >> /var/log/spacelift/info.log
+  echo "No CA certificates provided via variables to install." >> /var/log/spacelift/info.log
   %{ endif ~}
+
+  if [[ "${load_custom_certs}" == "true" ]]; then
+    echo "Fetching custom CA certificate from AWS S3..." >> /var/log/spacelift/info.log
+
+    if [[ -z "${s3_bucket_name}" ]] || [[ -z "${s3_object_key}" ]]; then
+      echo "Error: s3_bucket_name and s3_object_key variables must be set when load_custom_certs is true." >> /var/log/spacelift/info.log
+      return 1
+    fi
+
+    local ca_bundle_path="/etc/pki/ca-trust/source/anchors/s3-custom-ca.crt"
+    echo "Downloading custom CA from s3://${s3_bucket_name}/${s3_object_key} to $ca_bundle_path" >> /var/log/spacelift/info.log
+    
+    if ! aws s3 cp --no-verify-ssl "s3://${s3_bucket_name}/${s3_object_key}" "$ca_bundle_path"; then
+      echo "Error: Failed to download CA bundle from S3." >> /var/log/spacelift/info.log
+      return 1
+    fi
+    
+    certs_installed=true
+    echo "Successfully downloaded CA certificate from S3." >> /var/log/spacelift/info.log
+  else
+    echo "load_custom_certs is not 'true'. Skipping S3 certificate installation." >> /var/log/spacelift/info.log
+  fi
+
+  if [[ "$certs_installed" == true ]]; then
+    echo "New certificates were installed. Running update-ca-trust..." >> /var/log/spacelift/info.log
+    update-ca-trust
+    echo "CA Trust Store updated successfully." >> /var/log/spacelift/info.log
+  else
+    echo "No new certificates were installed. Skipping update-ca-trust." >> /var/log/spacelift/info.log
+  fi
 )}
 
 create_spacelift_launcher_script () {(
@@ -171,12 +201,37 @@ UNIT
   echo "Spacelift launcher started as systemd service" >> /var/log/spacelift/info.log
 )}
 
+manage_ssm_by_region () {
+  local aws_region="${region}"
+  local info_log="/var/log/spacelift/info.log"
+  local err_log="/var/log/spacelift/error.log"
+  {
+    echo "Checking AWS region for SSM restart requirement: $aws_region"
+    if [[ "$aws_region" == *-iso* ]]; then
+      echo "Instance is running in an AWS ADC region. Proceeding to restart the SSM agent."
+      if ! systemctl restart amazon-ssm-agent; then
+        echo "SSM Agent failed to restart, going to retry in 2 seconds..." >&2
+        sleep 2
+        if ! systemctl restart amazon-ssm-agent; then
+          echo "SSM Agent failed to restart again, requires manual intervention." >&2
+          return 1
+        fi
+      fi
+      
+      echo "SSM agent restarted successfully."
+    else
+      echo "Instance is running in AWS Commercial or GovCloud. No SSM restart required."
+    fi
+  } >> "$info_log" 2>> "$err_log"
+}
+
 disable_cloudwatch_agent
+load_custom_ca_certs
 configure_permissions
 download_launcher
 configure_docker
-load_custom_ca_certs
 create_spacelift_launcher_script
+manage_ssm_by_region
 
 if ! run_spacelift; then
   echo "Failed to start Spacelift launcher service, powering off in 15 seconds" >> /var/log/spacelift/error.log

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -201,12 +201,37 @@ UNIT
   echo "Spacelift launcher started as systemd service" >> /var/log/spacelift/info.log
 )}
 
+manage_ssm_by_region () {
+  local aws_region="${region}"
+  local info_log="/var/log/spacelift/info.log"
+  local err_log="/var/log/spacelift/error.log"
+  {
+    echo "Checking AWS region for SSM restart requirement: $aws_region"
+    if [[ "$aws_region" == *-iso* ]]; then
+      echo "Instance is running in an AWS ADC region. Proceeding to restart the SSM agent."
+      if ! systemctl restart amazon-ssm-agent; then
+        echo "SSM Agent failed to restart, going to retry in 2 seconds..." >&2
+        sleep 2
+        if ! systemctl restart amazon-ssm-agent; then
+          echo "SSM Agent failed to restart again, requires manual intervention." >&2
+          return 1
+        fi
+      fi
+      
+      echo "SSM agent restarted successfully."
+    else
+      echo "Instance is running in AWS Commercial or GovCloud. No SSM restart required."
+    fi
+  } >> "$info_log" 2>> "$err_log"
+}
+
 disable_cloudwatch_agent
 load_custom_ca_certs
 configure_permissions
 download_launcher
 configure_docker
 create_spacelift_launcher_script
+manage_ssm_by_region
 
 if ! run_spacelift; then
   echo "Failed to start Spacelift launcher service, powering off in 15 seconds" >> /var/log/spacelift/error.log

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -65,21 +65,21 @@ configure_docker () {(
 )}
 
 load_custom_ca_certs () {(
-  if [[ "${LOAD_CUSTOM_CERTS}" != "true" ]]; then
-    echo "LOAD_CUSTOM_CERTS is not set to true. Skipping CA certificate installation." >> /var/log/spacelift/info.log
+  if [[ "${load_custom_certs}" != "true" ]]; then
+    echo "load_custom_certs is not set to true. Skipping CA certificate installation." >> /var/log/spacelift/info.log
     return 0
   fi
 
   echo "Fetching custom CA certificate from AWS S3..." >> /var/log/spacelift/info.log
 
-  if [[ -z "${S3_BUCKET_NAME}" ]] || [[ -z "${S3_OBJECT_KEY}" ]]; then
-    echo "Error: S3_BUCKET_NAME and S3_OBJECT_KEY environment variables must be set." >> /var/log/spacelift/info.log
+  if [[ -z "${s3_bucket_name}" ]] || [[ -z "${s3_object_key}" ]]; then
+    echo "Error: s3_bucket_name and s3_object_key environment variables must be set." >> /var/log/spacelift/info.log
     return 1
   fi
 
   export CA_BUNDLE_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
-  echo "Downloading custom CA from s3://${S3_BUCKET_NAME}/${S3_OBJECT_KEY} to $CA_BUNDLE_PATH" >> /var/log/spacelift/info.log
-  aws s3 cp --no-verify-ssl "s3://${S3_BUCKET_NAME}/${S3_OBJECT_KEY}" "$CA_BUNDLE_PATH"
+  echo "Downloading custom CA from s3://${s3_bucket_name}/${s3_object_key} to $CA_BUNDLE_PATH" >> /var/log/spacelift/info.log
+  aws s3 cp --no-verify-ssl "s3://${s3_bucket_name}/${s3_object_key}" "$CA_BUNDLE_PATH"
 
   if [[ $? -ne 0 ]]; then
     echo "Error: Failed to download CA bundle from S3." >> /var/log/spacelift/info.log

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -65,19 +65,30 @@ configure_docker () {(
 )}
 
 load_custom_ca_certs () {(
-  set -e
+  if [[ "${LOAD_CUSTOM_CERTS}" != "true" ]]; then
+    echo "LOAD_CUSTOM_CERTS is not set to true. Skipping CA certificate installation." >> /var/log/spacelift/info.log
+    return 0
+  fi
 
-  %{ if length(ca_certificates) > 0 ~}
-  echo "Installing custom root CA certificates" >> /var/log/spacelift/info.log
-  %{ for cert in ca_certificates ~}
-  echo "${cert}" > /etc/pki/ca-trust/source/anchors/$(uuidgen).crt
-  %{ endfor ~}
+  echo "Fetching custom CA certificate from AWS S3..." >> /var/log/spacelift/info.log
 
-  sudo update-ca-trust
-  echo "Custom root CA certificates are GO" >> /var/log/spacelift/info.log
-  %{ else ~}
-  echo "No CA certificates to install." >> /var/log/spacelift/info.log
-  %{ endif ~}
+  if [[ -z "${S3_BUCKET_NAME}" ]] || [[ -z "${S3_OBJECT_KEY}" ]]; then
+    echo "Error: S3_BUCKET_NAME and S3_OBJECT_KEY environment variables must be set." >> /var/log/spacelift/info.log
+    return 1
+  fi
+
+  export CA_BUNDLE_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
+  echo "Downloading custom CA from s3://${S3_BUCKET_NAME}/${S3_OBJECT_KEY} to $CA_BUNDLE_PATH" >> /var/log/spacelift/info.log
+  aws s3 cp --no-verify-ssl "s3://${S3_BUCKET_NAME}/${S3_OBJECT_KEY}" "$CA_BUNDLE_PATH"
+
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to download CA bundle from S3." >> /var/log/spacelift/info.log
+    return 1
+  fi
+
+  echo "Running update-ca-trust..." >> /var/log/spacelift/info.log
+  update-ca-trust
+  echo "CA Trust Store updated successfully." >> /var/log/spacelift/info.log
 )}
 
 create_spacelift_launcher_script () {(
@@ -172,10 +183,10 @@ UNIT
 )}
 
 disable_cloudwatch_agent
+load_custom_ca_certs
 configure_permissions
 download_launcher
 configure_docker
-load_custom_ca_certs
 create_spacelift_launcher_script
 
 if ! run_spacelift; then

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -65,30 +65,49 @@ configure_docker () {(
 )}
 
 load_custom_ca_certs () {(
-  if [[ "${load_custom_certs}" != "true" ]]; then
-    echo "load_custom_certs is not set to true. Skipping CA certificate installation." >> /var/log/spacelift/info.log
-    return 0
+  set -e
+  local certs_installed=false
+
+  %{ if length(ca_certificates) > 0 ~}
+  echo "Installing custom root CA certificates from Terraform variables..." >> /var/log/spacelift/info.log
+  %{ for cert in ca_certificates ~}
+  echo "${cert}" > /etc/pki/ca-trust/source/anchors/$(uuidgen).crt
+  %{ endfor ~}
+  certs_installed=true
+  echo "Successfully installed CA certificates from variables." >> /var/log/spacelift/info.log
+  %{ else ~}
+  echo "No CA certificates provided via variables to install." >> /var/log/spacelift/info.log
+  %{ endif ~}
+
+  if [[ "${load_custom_certs}" == "true" ]]; then
+    echo "Fetching custom CA certificate from AWS S3..." >> /var/log/spacelift/info.log
+
+    if [[ -z "${s3_bucket_name}" ]] || [[ -z "${s3_object_key}" ]]; then
+      echo "Error: s3_bucket_name and s3_object_key variables must be set when load_custom_certs is true." >> /var/log/spacelift/info.log
+      return 1
+    fi
+
+    local ca_bundle_path="/etc/pki/ca-trust/source/anchors/s3-custom-ca.crt"
+    echo "Downloading custom CA from s3://${s3_bucket_name}/${s3_object_key} to $ca_bundle_path" >> /var/log/spacelift/info.log
+    
+    if ! aws s3 cp --no-verify-ssl "s3://${s3_bucket_name}/${s3_object_key}" "$ca_bundle_path"; then
+      echo "Error: Failed to download CA bundle from S3." >> /var/log/spacelift/info.log
+      return 1
+    fi
+    
+    certs_installed=true
+    echo "Successfully downloaded CA certificate from S3." >> /var/log/spacelift/info.log
+  else
+    echo "load_custom_certs is not 'true'. Skipping S3 certificate installation." >> /var/log/spacelift/info.log
   fi
 
-  echo "Fetching custom CA certificate from AWS S3..." >> /var/log/spacelift/info.log
-
-  if [[ -z "${s3_bucket_name}" ]] || [[ -z "${s3_object_key}" ]]; then
-    echo "Error: s3_bucket_name and s3_object_key environment variables must be set." >> /var/log/spacelift/info.log
-    return 1
+  if [[ "$certs_installed" == true ]]; then
+    echo "New certificates were installed. Running update-ca-trust..." >> /var/log/spacelift/info.log
+    update-ca-trust
+    echo "CA Trust Store updated successfully." >> /var/log/spacelift/info.log
+  else
+    echo "No new certificates were installed. Skipping update-ca-trust." >> /var/log/spacelift/info.log
   fi
-
-  export CA_BUNDLE_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
-  echo "Downloading custom CA from s3://${s3_bucket_name}/${s3_object_key} to $CA_BUNDLE_PATH" >> /var/log/spacelift/info.log
-  aws s3 cp --no-verify-ssl "s3://${s3_bucket_name}/${s3_object_key}" "$CA_BUNDLE_PATH"
-
-  if [[ $? -ne 0 ]]; then
-    echo "Error: Failed to download CA bundle from S3." >> /var/log/spacelift/info.log
-    return 1
-  fi
-
-  echo "Running update-ca-trust..." >> /var/log/spacelift/info.log
-  update-ca-trust
-  echo "CA Trust Store updated successfully." >> /var/log/spacelift/info.log
 )}
 
 create_spacelift_launcher_script () {(

--- a/variables.tf
+++ b/variables.tf
@@ -367,6 +367,9 @@ variable "selfhosted_configuration" {
   - https_proxy_config: (optional) The value of the HTTPS_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - no_proxy_config: (optional) The value of the NO_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - ca_certificates: (optional) List of additional root CAs to install on the instance. Example: ["-----BEGIN CERTIFICATE-----abc123-----END CERTIFICATE-----"].
+  - load_custom_certs: (optional) Boolean value true/false to enable loading custom certs from S3. Goes along with the next two configuration options.
+  - s3_bucket_name: (optional) The bucket name to pull a custom certificate bundle from S3
+  - s3_object_key: (optional) The object key/name of the certificate bundle.
   - power_off_on_error: (optional) Indicates whether the instance should poweroff when the launcher process exits. This allows the machine to be automatically be replaced by the ASG after error conditions. If an instance is crashing during startup, it can be useful to temporarily set this to false to allow you to connect to the instance and investigate.
   EOF
 
@@ -377,6 +380,9 @@ variable "selfhosted_configuration" {
     https_proxy_config             = optional(string)
     no_proxy_config                = optional(string)
     ca_certificates                = optional(list(string))
+    load_custom_certs              = optional(bool)
+    s3_bucket_name                 = optional(string)
+    s3_object_key                  = optional(string)
     power_off_on_error             = optional(bool)
   })
   default = {
@@ -386,6 +392,9 @@ variable "selfhosted_configuration" {
     https_proxy_config             = ""
     no_proxy_config                = ""
     ca_certificates                = []
+    load_custom_certs              = false
+    s3_bucket_name                 = ""
+    s3_object_key                  = ""
     power_off_on_error             = true
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -366,6 +366,7 @@ variable "selfhosted_configuration" {
   - http_proxy_config: (optional) The value of the HTTP_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - https_proxy_config: (optional) The value of the HTTPS_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - no_proxy_config: (optional) The value of the NO_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
+  - ca_certificates: (optional) List of additional root CAs to install on the instance. Example: ["-----BEGIN CERTIFICATE-----abc123-----END CERTIFICATE-----"].
   - load_custom_certs: (optional) Boolean value true/false to enable loading custom certs from S3. Goes along with the next two configuration options.
   - s3_bucket_name: (optional) The bucket name to pull a custom certificate bundle from S3
   - s3_object_key: (optional) The object key/name of the certificate bundle.
@@ -378,6 +379,7 @@ variable "selfhosted_configuration" {
     http_proxy_config              = optional(string)
     https_proxy_config             = optional(string)
     no_proxy_config                = optional(string)
+    ca_certificates                = optional(list(string))
     load_custom_certs              = optional(bool)
     s3_bucket_name                 = optional(string)
     s3_object_key                  = optional(string)
@@ -389,6 +391,7 @@ variable "selfhosted_configuration" {
     http_proxy_config              = ""
     https_proxy_config             = ""
     no_proxy_config                = ""
+    ca_certificates                = []
     load_custom_certs              = false
     s3_bucket_name                 = ""
     s3_object_key                  = ""

--- a/variables.tf
+++ b/variables.tf
@@ -450,3 +450,20 @@ variable "manage_log_groups" {
   type        = bool
   default     = true
 }
+variable "s3_bucket_name" {
+  type        = string
+  default     = ""
+  description = "Bucket name to pull the certificate bundle for the workers"
+}
+
+variable "s3_object_key" {
+  type        = string
+  default     = ""
+  description = "Object key for the certificate bundle you want to download"
+}
+
+variable "load_custom_certs" {
+  type        = bool
+  default     = false
+  description = "Boolean to load custom certs to the worker if desired"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -366,7 +366,9 @@ variable "selfhosted_configuration" {
   - http_proxy_config: (optional) The value of the HTTP_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - https_proxy_config: (optional) The value of the HTTPS_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
   - no_proxy_config: (optional) The value of the NO_PROXY environment variable to pass to the launcher, worker containers, and Docker daemon.
-  - ca_certificates: (optional) List of additional root CAs to install on the instance. Example: ["-----BEGIN CERTIFICATE-----abc123-----END CERTIFICATE-----"].
+  - load_custom_certs: (optional) Boolean value true/false to enable loading custom certs from S3. Goes along with the next two configuration options.
+  - s3_bucket_name: (optional) The bucket name to pull a custom certificate bundle from S3
+  - s3_object_key: (optional) The object key/name of the certificate bundle.
   - power_off_on_error: (optional) Indicates whether the instance should poweroff when the launcher process exits. This allows the machine to be automatically be replaced by the ASG after error conditions. If an instance is crashing during startup, it can be useful to temporarily set this to false to allow you to connect to the instance and investigate.
   EOF
 
@@ -376,7 +378,9 @@ variable "selfhosted_configuration" {
     http_proxy_config              = optional(string)
     https_proxy_config             = optional(string)
     no_proxy_config                = optional(string)
-    ca_certificates                = optional(list(string))
+    load_custom_certs              = optional(bool)
+    s3_bucket_name                 = optional(string)
+    s3_object_key                  = optional(string)
     power_off_on_error             = optional(bool)
   })
   default = {
@@ -385,7 +389,9 @@ variable "selfhosted_configuration" {
     http_proxy_config              = ""
     https_proxy_config             = ""
     no_proxy_config                = ""
-    ca_certificates                = []
+    load_custom_certs              = false
+    s3_bucket_name                 = ""
+    s3_object_key                  = ""
     power_off_on_error             = true
   }
 }
@@ -449,21 +455,4 @@ variable "manage_log_groups" {
   description = "Whether to manage the CloudWatch Log Group for the worker instances. If false, the log group must be managed by the caller."
   type        = bool
   default     = true
-}
-variable "s3_bucket_name" {
-  type        = string
-  default     = ""
-  description = "Bucket name to pull the certificate bundle for the workers"
-}
-
-variable "s3_object_key" {
-  type        = string
-  default     = ""
-  description = "Object key for the certificate bundle you want to download"
-}
-
-variable "load_custom_certs" {
-  type        = bool
-  default     = false
-  description = "Boolean to load custom certs to the worker if desired"
 }


### PR DESCRIPTION
## Description of the change

This PR addresses an issue with adding certificates to the EC2 instances. The current documentation for adding certificates to "docker based workers" does not work when running them in EC2 on aws. It overloads the user-data byte size. This method pulls certificates from S3. It adds one additional iam policy to support the user to pull the certificates from a different S3 bucket if than the launcher. Additionally it adds a boolean check to disable pulling in the extra certs if not needed. 

The exisiting method of adding certificates under the "ca_certificates" variable worked for smaller certificate chains, it did not support larger certificate chains as needed to support deploying Spacelift to the AWS ADC regions. Those cert chains are over 3k lines. That is why this change is necessary.

The reason for downloading the certificates with the "--no-verify-ssl" option is to support the AWS ADC regions where you need to download their certificate before setting up the launcher script and everything coming up. This way the certificate is first download to the box, then update certificates is run, then commands further down will run as usual. 

## Type of change

- [x ] Bug fix (non-breaking change that fixes an issue);
- [x ] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds optional bootstrap logic and IAM permissions to download and install a custom CA bundle from S3 during instance startup, which can affect TLS behavior and instance provisioning if misconfigured. Terraform may fail to apply due to the new policy name referencing `random_string.iam_suffix` (not found in this repo snapshot).
> 
> **Overview**
> Self-hosted workers can now *optionally* install custom root CAs by downloading a certificate bundle from S3 at boot (guarded by `selfhosted_configuration.load_custom_certs`), instead of embedding large cert chains in user-data.
> 
> This wires new `selfhosted_configuration` inputs (`load_custom_certs`, `s3_bucket_name`, `s3_object_key`) into the self-hosted user-data template, runs the CA install step earlier in startup, and conditionally attaches an additional IAM policy allowing `s3:GetObject` for the specified S3 object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e2035311dd55533f4216461785a8cc31b0e687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->