### PR TITLE
fix: store CA bundle in Secrets Manager to avoid Lambda 4KB env var limit

### DIFF
--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -6,6 +6,10 @@ locals {
   use_s3_package     = var.autoscaling_configuration.s3_package != null
   resolve_latest     = var.autoscaling_configuration.version == "latest"
   autoscaler_version = !local.use_s3_package && local.resolve_latest ? jsondecode(data.http.latest_release[0].response_body).tag_name : var.autoscaling_configuration.version
+
+  # CA bundle is stored in Secrets Manager to avoid exceeding the Lambda 4KB env var limit.
+  ca_bundle_secret_name = "${local.function_name}-ca-bundle"
+  ca_bundle_env         = var.autoscaling_configuration.ca_bundle != null ? { SPACELIFT_CA_BUNDLE_SECRET_NAME = local.ca_bundle_secret_name } : {}
 }
 
 # When version = "latest", resolve to a concrete release tag via the GitHub API.
@@ -107,7 +111,7 @@ resource "aws_lambda_function" "autoscaler" {
       AUTOSCALING_MAX_CREATE        = var.autoscaling_configuration.max_create != null ? var.autoscaling_configuration.max_create : 1
       AUTOSCALING_MAX_KILL          = var.autoscaling_configuration.max_terminate != null ? var.autoscaling_configuration.max_terminate : 1
       AUTOSCALING_SCALE_DOWN_DELAY  = var.autoscaling_configuration.scale_down_delay != null ? var.autoscaling_configuration.scale_down_delay : 0
-    }, var.autoscaling_configuration.ca_bundle != null ? { SPACELIFT_CA_BUNDLE = var.autoscaling_configuration.ca_bundle } : {}, var.extra_env)
+    }, local.ca_bundle_env, var.extra_env)
   }
 
   tracing_config {
@@ -137,4 +141,20 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda" {
 resource "aws_cloudwatch_log_group" "log_group" {
   name              = "/aws/lambda/${local.function_name}"
   retention_in_days = var.cloudwatch_log_group_retention
+}
+
+resource "aws_secretsmanager_secret" "ca_bundle" {
+  count = var.autoscaling_configuration.ca_bundle != null ? 1 : 0
+
+  name                    = local.ca_bundle_secret_name
+  recovery_window_in_days = 0
+  description             = "CA bundle for the Spacelift autoscaler Lambda of worker pool ${var.worker_pool_id}"
+  tags                    = var.additional_tags
+}
+
+resource "aws_secretsmanager_secret_version" "ca_bundle" {
+  count = var.autoscaling_configuration.ca_bundle != null ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.ca_bundle[0].id
+  secret_string = var.autoscaling_configuration.ca_bundle
 }

--- a/autoscaler/iam.tf
+++ b/autoscaler/iam.tf
@@ -64,6 +64,15 @@ data "aws_iam_policy_document" "autoscaler" {
     actions   = ["ssm:GetParameter"]
     resources = [var.api_key_ssm_parameter_arn]
   }
+
+  dynamic "statement" {
+    for_each = var.autoscaling_configuration.ca_bundle != null ? [1] : []
+    content {
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = [aws_secretsmanager_secret.ca_bundle[0].arn]
+    }
+  }
 }
 
 resource "aws_iam_role" "autoscaler" {

--- a/examples/autoscaler-ca-bundle/variables.tf
+++ b/examples/autoscaler-ca-bundle/variables.tf
@@ -16,5 +16,5 @@ variable "spacelift_api_key_endpoint" {
 
 variable "ca_bundle" {
   type        = string
-  description = "Base64-encoded PEM certificate or certificate chain for the autoscaler to trust when connecting to the Spacelift API. Example: base64encode(file(\"ca.pem\"))."
+  description = "PEM certificate or certificate chain for the autoscaler to trust when connecting to the Spacelift API. Example: file(\"ca.pem\"). The value is stored in AWS Secrets Manager to avoid exceeding the Lambda 4KB environment variable limit."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -306,7 +306,7 @@ variable "autoscaling_configuration" {
     - key: (mandatory) S3 object key
     - object_version: (optional) S3 object version
   - scale_down_delay: (optional) The number of minutes a worker must be registered to spacelift before it is eligible for termination. Default: 0 minutes.
-  - ca_bundle: (optional) Base64-encoded PEM certificate or certificate chain to trust when the autoscaler connects to the Spacelift API. Useful for self-hosted deployments with a private CA. Example: base64encode(file("ca.pem")).
+  - ca_bundle: (optional) PEM certificate or certificate chain to trust when the autoscaler connects to the Spacelift API. Useful for self-hosted deployments with a private CA. The value is stored in AWS Secrets Manager to avoid exceeding the Lambda 4KB environment variable limit. Example: file("ca.pem").
   EOF
 
   type = object({


### PR DESCRIPTION
## Summary

- The `ca_bundle` in `autoscaling_configuration` was previously injected directly as `SPACELIFT_CA_BUNDLE` in the Lambda environment variables
- Lambda enforces a **4KB limit** on environment variables — CA bundles larger than ~3KB exceed this after encoding, causing deployment failures
- This PR stores the CA bundle in an AWS Secrets Manager secret instead, and passes `SPACELIFT_CA_BUNDLE_SECRET_NAME` to the Lambda so it can fetch the value at runtime

## Changes

- **`autoscaler/autoscaler.tf`**: Creates `aws_secretsmanager_secret` + `aws_secretsmanager_secret_version` when `ca_bundle` is set; passes `SPACELIFT_CA_BUNDLE_SECRET_NAME` env var instead of `SPACELIFT_CA_BUNDLE`
- **`autoscaler/iam.tf`**: Adds `secretsmanager:GetSecretValue` permission on the CA bundle secret when set
- **`variables.tf` / `examples/autoscaler-ca-bundle/variables.tf`**: Updated descriptions to reflect the new storage mechanism and remove the `base64encode` requirement

## Notes

- This is a **breaking change** for existing users of `ca_bundle` — the Lambda env var changes from `SPACELIFT_CA_BUNDLE` to `SPACELIFT_CA_BUNDLE_SECRET_NAME`, so the autoscaler binary must be updated to read from Secrets Manager using this env var
- The `ca_bundle` input value no longer needs to be base64-encoded; pass the raw PEM content (e.g. `file("ca.pem")`)

## Test plan

- [ ] Deploy with a `ca_bundle` larger than 4KB and verify Lambda creates successfully
- [ ] Verify the Secrets Manager secret is created with the correct content
- [ ] Verify the Lambda IAM role has `secretsmanager:GetSecretValue` on the secret
- [ ] Verify `SPACELIFT_CA_BUNDLE_SECRET_NAME` is set correctly in the Lambda environment
- [ ] Deploy without `ca_bundle` and verify no Secrets Manager resources are created