### PR TITLE
feat: unify env var passing via single env_vars variable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 6.1.0
+module_version: 7.0.0
 
 tests:
   - name: AMD64-based workerpool

--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -56,6 +56,16 @@ tests:
       TF_VAR_spacelift_api_key_secret: "EXAMPLE22anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
       TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
 
+  - name: env-vars (plain and sensitive)
+    project_root: examples/env-vars
+
+  - name: secret-env-var-arns (with autoscaler)
+    project_root: examples/secret-env-var-arns
+    environment:
+      TF_VAR_spacelift_api_key_id: "EXAMPLE0VOYU49U485BMZZVAWXU59JOEY1"
+      TF_VAR_spacelift_api_key_secret: "EXAMPLE22anuofh4b6a4e43aplqt49099606de2mzbq4391tj1d3dc9872q23z8fvctu4kh"
+      TF_VAR_spacelift_api_key_endpoint: "https://example.app.spacelift.io"
+
   - name: With autoscaling and custom CA bundle
     project_root: examples/autoscaler-ca-bundle
     environment:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ provider "aws" {
 }
 
 module "spacelift_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.3.1"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v7.0.0"
 
   env_vars = {
     SPACELIFT_TOKEN = {
@@ -231,7 +231,7 @@ Configure spot instances using the `instance_market_options` variable:
 
 ```hcl
 module "spacelift_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v7.0.0"
 
   # ... other configuration ...
 
@@ -289,7 +289,7 @@ If you don't need detailed instance-level metrics, you can disable the CloudWatc
 
 ```hcl
 module "spacelift_workerpool" {
-  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v7.0.0"
 
   # ... other configuration ...
 

--- a/README.md
+++ b/README.md
@@ -40,20 +40,25 @@ provider "aws" {
 module "spacelift_workerpool" {
   source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2?ref=v5.3.1"
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = var.worker_pool_config
-    SPACELIFT_POOL_PRIVATE_KEY = var.worker_pool_private_key
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = var.worker_pool_config
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = var.worker_pool_private_key
+      sensitive = true
+    }
+    SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED = {
+      value = "true"
+    }
   }
 
-  configuration = <<EOF
-    export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
-  EOF
-
-  min_size          = 1
-  max_size          = 5
-  worker_pool_id    = var.worker_pool_id
-  security_groups   = var.security_groups
-  vpc_subnets       = var.subnets
+  min_size        = 1
+  max_size        = 5
+  worker_pool_id  = var.worker_pool_id
+  security_groups = var.security_groups
+  vpc_subnets     = var.subnets
 }
 ```
 
@@ -71,25 +76,47 @@ For more examples covering specific use cases, please see the [examples director
 - [Custom IAM role](./examples/custom-iam-role/)
 - [Self-hosted deployment](./examples/self-hosted/)
 
-## 🔑 Credentials Management
+## 🔑 Credentials & Environment Variables
 
-### Using `secure_env_vars` (Recommended)
+### Using `env_vars` (Recommended)
 
-The recommended approach for managing sensitive worker pool credentials is to use the `secure_env_vars` variable:
+All environment variables — for EC2 workers, the autoscaler Lambda, and the lifecycle manager Lambda — are passed through a single `env_vars` variable. Each entry supports three kinds of values:
 
 ```hcl
-secure_env_vars = {
-  SPACELIFT_TOKEN            = var.worker_pool_config
-  SPACELIFT_POOL_PRIVATE_KEY = var.worker_pool_private_key
+env_vars = {
+  # 1. Plain value — visible in Terraform state, passed as-is.
+  LOG_LEVEL = {
+    value = "info"
+  }
+
+  # 2. Sensitive value — redacted in plan/apply output, stored in
+  #    AWS Secrets Manager and fetched by EC2 workers at startup.
+  SPACELIFT_TOKEN = {
+    value     = var.worker_pool_config
+    sensitive = true
+  }
+  SPACELIFT_POOL_PRIVATE_KEY = {
+    value     = var.worker_pool_private_key
+    sensitive = true
+  }
+
+  # 3. Secret ARN — Terraform never sees the value. EC2 workers fetch
+  #    it individually at startup; Lambda functions receive a
+  #    NAME_SECRET_ARN env var they can use to retrieve it at runtime.
+  DB_PASSWORD = {
+    secret_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:prod/db/password-AbCdEf"
+  }
 }
 ```
 
-When you provide credentials via `secure_env_vars`:
-- The module creates AWS Secrets Manager resources to securely store these values
-- Values are encrypted at rest and only accessed by the worker instances at runtime
-- The credentials are exported as environment variables in the worker's environment
+**How each kind is handled per component:**
 
-> ❗️ Previous versions of this module (`<v3`) placed the token and private key directly into the `configuration` variable. This is still supported for [non-sensitive configuration options](https://docs.spacelift.io/concepts/worker-pools.html#configuration-options), but for the worker pool token and private key, it is highly recommended to use the `secure_env_vars` variable.
+| Kind | EC2 workers | Autoscaler Lambda | Lifecycle manager Lambda |
+|---|---|---|---|
+| `value` | Stored in Secrets Manager bundle, exported at boot | Direct env var | Direct env var |
+| `secret_arn` | Fetched individually at boot via `aws secretsmanager get-secret-value` | `NAME_SECRET_ARN` env var + IAM access | `NAME_SECRET_ARN` env var + IAM access |
+
+> ❗️ Previous versions of this module used separate `secure_env_vars` and `autoscaler_extra_env` variables. These have been replaced by `env_vars`. The `configuration` variable remains available for non-env-var user data.
 
 ### Using "Bring Your Own" (BYO) Variables
 
@@ -113,11 +140,11 @@ byo_ssm = {
 
 #### Important: Mutual Exclusivity
 
-> ⚠️ **Important:** When using `byo_secretsmanager`, you should not use `secure_env_vars` for the same environment variables. These approaches are mutually exclusive for any given variable.
+> ⚠️ **Important:** `byo_secretsmanager` and `env_vars` entries with plain/sensitive `value`s are mutually exclusive — use one or the other to manage the EC2 worker secret bundle.
 >
-> - Use `secure_env_vars` when you want the module to manage your Secrets Manager resources
+> - Use `env_vars` when you want the module to manage your Secrets Manager resources
 > - Use `byo_secretsmanager` when you have pre-existing Secrets Manager resources or need more control
-> - If you use both, `byo_secretsmanager` takes precedence for the keys specified in its `keys` list
+> - `env_vars` entries with `secret_arn` (referencing external secrets) are always compatible with `byo_secretsmanager`
 
 Similarly, when using `byo_ssm` for the autoscaler API credentials, you should not provide `api_key_secret` in the `spacelift_api_credentials` object, as these are mutually exclusive ways to provide the same information:
 

--- a/asg.tf
+++ b/asg.tf
@@ -2,7 +2,7 @@ data "aws_region" "this" {}
 
 locals {
   selfhosted_user_data = templatefile("${path.module}/user_data/selfhosted.tftpl", {
-    custom_user_data               = join("\n", [replace(local.secure_env_vars, "$", "\\$"), var.configuration])
+    custom_user_data               = join("\n", [replace(local.secure_env_vars, "$", "\\$"), replace(local.env_vars_secret_arn_exports, "$", "\\$"), var.configuration])
     run_launcher_as_spacelift_user = var.selfhosted_configuration.run_launcher_as_spacelift_user == null ? true : var.selfhosted_configuration.run_launcher_as_spacelift_user
     launcher_s3_uri                = var.selfhosted_configuration.s3_uri
     http_proxy_config              = var.selfhosted_configuration.http_proxy_config == null ? "" : var.selfhosted_configuration.http_proxy_config
@@ -18,7 +18,7 @@ locals {
   })
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {
-    custom_user_data         = join("\n", [local.secure_env_vars, var.configuration])
+    custom_user_data         = join("\n", [local.secure_env_vars, local.env_vars_secret_arn_exports, var.configuration])
     domain_name              = var.domain_name
     poweroff_delay           = var.poweroff_delay
     region                   = data.aws_region.this.region

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -1,21 +1,58 @@
 locals {
+  # Non-sensitive value entries — passed directly as Lambda env vars.
   env_vars_direct = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null
+    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive != true
   }
 
-  env_vars_secret_refs = {
+  # Sensitive value entries — stored as individual Secrets Manager secrets so
+  # the value is never embedded in the Lambda configuration.
+  env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
-    "${name}_SECRET_ARN" => cfg.secret_arn
-    if cfg.secret_arn != null
+    name => cfg.value
+    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive == true
   }
 
-  env_vars_secret_arns = [
-    for name, cfg in var.env_vars :
-    cfg.secret_arn
-    if cfg.secret_arn != null
-  ]
+  # NAME_SECRET_ARN env vars: explicit secret_arn entries + sensitive value secrets.
+  env_vars_secret_refs = merge(
+    { for name, cfg in var.env_vars :
+      "${name}_SECRET_ARN" => cfg.secret_arn
+    if cfg.secret_arn != null },
+    { for name, secret in aws_secretsmanager_secret.sensitive_env_var :
+    "${name}_SECRET_ARN" => secret.arn }
+  )
+
+  # All secret ARNs the Lambda IAM role needs to read.
+  env_vars_secret_arns = concat(
+    [for name, cfg in var.env_vars : cfg.secret_arn if cfg.secret_arn != null],
+    [for _, secret in aws_secretsmanager_secret.sensitive_env_var : secret.arn],
+  )
+
+  uses_secrets_extension = length(local.env_vars_secret_arns) > 0
+}
+
+# Individual Secrets Manager secrets for each sensitive value entry.
+resource "aws_secretsmanager_secret" "sensitive_env_var" {
+  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+
+  name                    = "${local.function_name}-env-${each.key}"
+  recovery_window_in_days = 0
+  tags                    = var.additional_tags
+}
+
+resource "aws_secretsmanager_secret_version" "sensitive_env_var" {
+  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+
+  secret_id     = aws_secretsmanager_secret.sensitive_env_var[each.key].id
+  secret_string = local.env_vars_sensitive_values[each.key]
+}
+
+# Resolve the AWS Parameters and Secrets Lambda Extension layer ARN for this
+# region and architecture via the public SSM parameter AWS maintains.
+data "aws_ssm_parameter" "secrets_extension_layer" {
+  count = local.uses_secrets_extension ? 1 : 0
+  name  = "/aws/service/aws-parameters-and-secrets-lambda-extension/${local.architecture == "arm64" ? "arm64" : "x86"}/latest"
 }
 
 locals {
@@ -106,6 +143,7 @@ resource "aws_lambda_function" "autoscaler" {
   runtime       = "provided.al2023"
   architectures = [var.autoscaling_configuration.architecture == "amd64" ? "x86_64" : coalesce(var.autoscaling_configuration.architecture, "x86_64")]
   timeout       = var.autoscaling_configuration.timeout != null ? var.autoscaling_configuration.timeout : 30
+  layers        = local.uses_secrets_extension ? [data.aws_ssm_parameter.secrets_extension_layer[0].value] : []
 
   dynamic "vpc_config" {
     for_each = var.spacelift_vpc_subnet_ids != null && var.spacelift_vpc_security_group_ids != null ? ["USE_VPC_CONFIG"] : []

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -1,4 +1,24 @@
 locals {
+  env_vars_direct = {
+    for name, cfg in var.env_vars :
+    name => cfg.value
+    if cfg.secret_arn == null && cfg.value != null
+  }
+
+  env_vars_secret_refs = {
+    for name, cfg in var.env_vars :
+    "${name}_SECRET_ARN" => cfg.secret_arn
+    if cfg.secret_arn != null
+  }
+
+  env_vars_secret_arns = [
+    for name, cfg in var.env_vars :
+    cfg.secret_arn
+    if cfg.secret_arn != null
+  ]
+}
+
+locals {
   download_folder    = var.worker_pool_id # Unique folder name to avoid race conditions when downloading the archive in parallel
   architecture       = coalesce(var.autoscaling_configuration.architecture, "amd64")
   autoscaler_zip     = "${local.download_folder}/ec2-workerpool-autoscaler_linux_${local.architecture}.zip"
@@ -107,7 +127,7 @@ resource "aws_lambda_function" "autoscaler" {
       AUTOSCALING_MAX_CREATE        = var.autoscaling_configuration.max_create != null ? var.autoscaling_configuration.max_create : 1
       AUTOSCALING_MAX_KILL          = var.autoscaling_configuration.max_terminate != null ? var.autoscaling_configuration.max_terminate : 1
       AUTOSCALING_SCALE_DOWN_DELAY  = var.autoscaling_configuration.scale_down_delay != null ? var.autoscaling_configuration.scale_down_delay : 0
-    }, var.autoscaling_configuration.ca_bundle != null ? { SPACELIFT_CA_BUNDLE = var.autoscaling_configuration.ca_bundle } : {}, var.extra_env)
+    }, var.autoscaling_configuration.ca_bundle != null ? { SPACELIFT_CA_BUNDLE = var.autoscaling_configuration.ca_bundle } : {}, local.env_vars_direct, local.env_vars_secret_refs)
   }
 
   tracing_config {

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -3,7 +3,7 @@ locals {
   env_vars_direct = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive != true
+    if cfg.value != null && cfg.sensitive != true
   }
 
   # Sensitive value entries — stored as individual Secrets Manager secrets so
@@ -11,25 +11,22 @@ locals {
   env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive == true
+    if cfg.value != null && cfg.sensitive == true
   }
 
-  # NAME_SECRET_ARN env vars: explicit secret_arn entries + sensitive value secrets.
+  # NAME_SECRET_ARN env vars: explicit secret_env_var_arns entries + sensitive value secrets.
   env_vars_secret_refs = merge(
-    { for name, cfg in var.env_vars :
-      "${name}_SECRET_ARN" => cfg.secret_arn
-    if cfg.secret_arn != null },
-    { for name, secret in aws_secretsmanager_secret.sensitive_env_var :
-    "${name}_SECRET_ARN" => secret.arn }
+    { for name, arn in var.secret_env_var_arns : "${name}_SECRET_ARN" => arn },
+    { for name, secret in aws_secretsmanager_secret.sensitive_env_var : "${name}_SECRET_ARN" => secret.arn }
   )
 
   # All secret ARNs the Lambda IAM role needs to read.
   env_vars_secret_arns = concat(
-    [for name, cfg in var.env_vars : cfg.secret_arn if cfg.secret_arn != null],
+    values(var.secret_env_var_arns),
     [for _, secret in aws_secretsmanager_secret.sensitive_env_var : secret.arn],
   )
 
-  uses_secrets_extension = length(local.env_vars_secret_arns) > 0
+  uses_secrets_extension = length(var.secret_env_var_arns) > 0 || length(local.env_vars_sensitive_values) > 0
 }
 
 # Individual Secrets Manager secrets for each sensitive value entry.

--- a/autoscaler/iam.tf
+++ b/autoscaler/iam.tf
@@ -64,6 +64,15 @@ data "aws_iam_policy_document" "autoscaler" {
     actions   = ["ssm:GetParameter"]
     resources = [var.api_key_ssm_parameter_arn]
   }
+
+  dynamic "statement" {
+    for_each = length(local.env_vars_secret_arns) > 0 ? ["USE_SECRETS"] : []
+    content {
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = local.env_vars_secret_arns
+    }
+  }
 }
 
 resource "aws_iam_role" "autoscaler" {

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -104,9 +104,14 @@ variable "env_vars" {
   description = "Environment variables to pass to the autoscaler Lambda function."
   sensitive   = true
   type = map(object({
-    value      = optional(string)
-    sensitive  = optional(bool, false)
-    secret_arn = optional(string)
+    value     = optional(string)
+    sensitive = optional(bool, false)
   }))
   default = {}
+}
+
+variable "secret_env_var_arns" {
+  description = "Map of environment variable name to an existing Secrets Manager secret ARN."
+  type        = map(string)
+  default     = {}
 }

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -100,8 +100,13 @@ variable "ipv6_allowed_for_dual_stack" {
   default     = null
 }
 
-variable "extra_env" {
-  description = "Additional environment variables to pass to the autoscaler Lambda function."
-  type        = map(string)
-  default     = {}
+variable "env_vars" {
+  description = "Environment variables to pass to the autoscaler Lambda function."
+  sensitive   = true
+  type = map(object({
+    value      = optional(string)
+    sensitive  = optional(bool, false)
+    secret_arn = optional(string)
+  }))
+  default = {}
 }

--- a/checks.tf
+++ b/checks.tf
@@ -37,11 +37,3 @@ The instance refresh functionality requires api credentials to be passed in the 
 EOT
 }
 
-resource "validation_error" "cannot_provide_byo_secretsmanager_and_env_vars_with_value" {
-  condition = local.byo_secretsmanager && length(local.env_vars_with_value) > 0
-  summary   = "Cannot provide both 'byo_secretsmanager' and env_vars entries with values"
-  details   = <<EOT
-'byo_secretsmanager' and 'env_vars' entries with plain/sensitive values are mutually exclusive.
-Use 'byo_secretsmanager' to bring your own secret bundle, or use 'env_vars' to let the module manage it.
-EOT
-}

--- a/checks.tf
+++ b/checks.tf
@@ -13,11 +13,11 @@ locals {
   ])
 }
 
-resource "validation_error" "secure_env_vars_or_configuration" {
-  condition = !local.has_secure_env_vars && var.configuration == ""
-  summary   = "Either var.secure_env_vars, var.byo_secretsmanager, or var.configuration must be set"
+resource "validation_error" "env_vars_or_configuration" {
+  condition = !local.has_secure_env_vars && length(local.env_vars_with_secret_arn) == 0 && var.configuration == ""
+  summary   = "Either var.env_vars, var.byo_secretsmanager, or var.configuration must be set"
   details   = <<EOT
-You must supply either 'secure_env_vars', 'var.byo_secretsmanager' or 'configuration' to the module.
+You must supply either 'env_vars', 'var.byo_secretsmanager' or 'configuration' to the module.
 EOT
 }
 
@@ -37,11 +37,11 @@ The instance refresh functionality requires api credentials to be passed in the 
 EOT
 }
 
-resource "validation_error" "cannot_provide_byo_secretsmanager_and_secure_env_vars" {
-  condition = local.byo_secretsmanager && (var.secure_env_vars != null && length(var.secure_env_vars) > 0)
-  summary   = "Cannot provide both 'byo_secretsmanager' and 'secure_env_vars'"
+resource "validation_error" "cannot_provide_byo_secretsmanager_and_env_vars_with_value" {
+  condition = local.byo_secretsmanager && length(local.env_vars_with_value) > 0
+  summary   = "Cannot provide both 'byo_secretsmanager' and env_vars entries with values"
   details   = <<EOT
-The 'byo_secretsmanager' and 'secure_env_vars' variables are mutually exclusive.
-Please provide only one of them.
+'byo_secretsmanager' and 'env_vars' entries with plain/sensitive values are mutually exclusive.
+Use 'byo_secretsmanager' to bring your own secret bundle, or use 'env_vars' to let the module manage it.
 EOT
 }

--- a/checks.tf
+++ b/checks.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "validation_error" "env_vars_or_configuration" {
-  condition = !local.has_secure_env_vars && length(local.env_vars_with_secret_arn) == 0 && var.configuration == ""
+  condition = !local.has_secure_env_vars && length(var.secret_env_var_arns) == 0 && var.configuration == ""
   summary   = "Either var.env_vars, var.byo_secretsmanager, or var.configuration must be set"
   details   = <<EOT
 You must supply either 'env_vars', 'var.byo_secretsmanager' or 'configuration' to the module.

--- a/examples/amd64/main.tf
+++ b/examples/amd64/main.tf
@@ -58,9 +58,15 @@ module "this" {
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
     export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
   EOT
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/arm64/main.tf
+++ b/examples/arm64/main.tf
@@ -57,9 +57,15 @@ module "this" {
   configuration = <<-EOT
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
   EOT
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/autoscaler-ca-bundle/main.tf
+++ b/examples/autoscaler-ca-bundle/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/autoscaler-custom-ebs-throughput/main.tf
+++ b/examples/autoscaler-custom-ebs-throughput/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/autoscaler-custom-s3-package/main.tf
+++ b/examples/autoscaler-custom-s3-package/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/autoscaler/main.tf
+++ b/examples/autoscaler/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -83,9 +83,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/env-vars/main.tf
+++ b/examples/env-vars/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+
+    random = { source = "hashicorp/random" }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      TfModule = "terraform-aws-spacelift-workerpool-on-ec2"
+      TestCase = "env-vars"
+    }
+  }
+}
+
+data "aws_vpc" "this" {
+  default = true
+}
+
+data "aws_security_group" "this" {
+  name   = "default"
+  vpc_id = data.aws_vpc.this.id
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+resource "random_string" "worker_pool_id" {
+  length           = 26
+  numeric          = true
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
+#### Spacelift worker pool ####
+
+module "this" {
+  source = "../../"
+
+  worker_pool_id = random_string.worker_pool_id.id
+
+  # Mix of plain and sensitive env_vars entries.
+  env_vars = {
+    # Plain value — passed as-is in user data and directly as a Lambda env var.
+    LOG_LEVEL = {
+      value = "debug"
+    }
+    # Sensitive values — redacted in plan output, stored in Secrets Manager for
+    # EC2 workers and as individual Secrets Manager secrets for Lambda functions.
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
+  }
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+
+  manage_log_groups = false
+}

--- a/examples/extra-iam-statements/main.tf
+++ b/examples/extra-iam-statements/main.tf
@@ -58,9 +58,15 @@ module "this" {
     export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
     export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
   EOT
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/secret-env-var-arns/main.tf
+++ b/examples/secret-env-var-arns/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+
+    random = { source = "hashicorp/random" }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      TfModule = "terraform-aws-spacelift-workerpool-on-ec2"
+      TestCase = "secret-env-var-arns"
+    }
+  }
+}
+
+data "aws_vpc" "this" {
+  default = true
+}
+
+data "aws_security_group" "this" {
+  name   = "default"
+  vpc_id = data.aws_vpc.this.id
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+resource "random_string" "worker_pool_id" {
+  length           = 26
+  numeric          = true
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
+resource "random_pet" "secret" {
+  length = 4
+}
+
+# A pre-existing secret whose value Terraform never reads.
+# The ARN is resource-computed (unknown at plan time), which exercises the
+# plan-time safety of secret_env_var_arns.
+resource "aws_secretsmanager_secret" "db_password" {
+  name                    = "${random_pet.secret.id}-db-password"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = "supersecret"
+}
+
+#### Spacelift worker pool ####
+
+module "this" {
+  source = "../../"
+
+  worker_pool_id = random_string.worker_pool_id.id
+
+  # Sensitive values stored in Secrets Manager by the module.
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
+  }
+
+  # Reference an existing secret by ARN. Terraform never reads the value.
+  # EC2 workers fetch it at startup; Lambda functions receive DB_PASSWORD_SECRET_ARN
+  # and use the AWS Parameters and Secrets Lambda Extension to resolve it at runtime.
+  secret_env_var_arns = {
+    DB_PASSWORD = aws_secretsmanager_secret.db_password.arn
+  }
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+
+  autoscaling_vpc_sg_ids  = [data.aws_security_group.this.id]
+  autoscaling_vpc_subnets = data.aws_subnets.this.ids
+  autoscaling_configuration = {
+    max_create          = 2
+    max_terminate       = 2
+    architecture        = "amd64"
+    schedule_expression = "rate(1 minute)"
+    timeout             = 60
+  }
+  spacelift_api_credentials = {
+    api_key_endpoint = var.spacelift_api_key_endpoint
+    api_key_id       = var.spacelift_api_key_id
+    api_key_secret   = var.spacelift_api_key_secret
+  }
+
+  manage_log_groups = false
+}

--- a/examples/secret-env-var-arns/variables.tf
+++ b/examples/secret-env-var-arns/variables.tf
@@ -1,0 +1,15 @@
+variable "spacelift_api_key_id" {
+  type        = string
+  description = "ID of the Spacelift API key to use"
+}
+
+variable "spacelift_api_key_secret" {
+  type        = string
+  sensitive   = true
+  description = "Secret corresponding to the Spacelift API key to use"
+}
+
+variable "spacelift_api_key_endpoint" {
+  type        = string
+  description = "Full URL of the Spacelift API endpoint to use, eg. https://demo.app.spacelift.io"
+}

--- a/examples/self-hosted-vpc-autoscaler/main.tf
+++ b/examples/self-hosted-vpc-autoscaler/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/self-hosted/main.tf
+++ b/examples/self-hosted/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/examples/spot-instances/main.tf
+++ b/examples/spot-instances/main.tf
@@ -54,9 +54,15 @@ module "this" {
 
   worker_pool_id = random_string.worker_pool_id.id
 
-  secure_env_vars = {
-    SPACELIFT_TOKEN            = "<token-here>"
-    SPACELIFT_POOL_PRIVATE_KEY = "<private-key-here>"
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
   }
 
   security_groups = [data.aws_security_group.this.id]

--- a/iam.tf
+++ b/iam.tf
@@ -86,7 +86,7 @@ resource "aws_iam_role_policy" "s3" {
 }
 
 locals {
-  use_secure_env_vars = var.create_iam_role && (local.has_secure_env_vars || length(local.env_vars_secret_arns) > 0)
+  use_secure_env_vars = var.create_iam_role && (local.has_secure_env_vars || length(var.secret_env_var_arns) > 0)
 }
 
 resource "aws_iam_role_policy_attachment" "secure_env_vars" {
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "secure_env_vars" {
     actions = ["secretsmanager:GetSecretValue"]
     resources = compact(concat(
       local.has_secure_env_vars ? [local.secretsmanager_arn] : [],
-      local.env_vars_secret_arns,
+      values(var.secret_env_var_arns),
     ))
   }
 

--- a/iam.tf
+++ b/iam.tf
@@ -86,7 +86,7 @@ resource "aws_iam_role_policy" "s3" {
 }
 
 locals {
-  use_secure_env_vars = alltrue([local.has_secure_env_vars, var.create_iam_role])
+  use_secure_env_vars = var.create_iam_role && (local.has_secure_env_vars || length(local.env_vars_secret_arns) > 0)
 }
 
 resource "aws_iam_role_policy_attachment" "secure_env_vars" {
@@ -113,11 +113,12 @@ data "aws_iam_policy_document" "secure_env_vars" {
   count = local.use_secure_env_vars ? 1 : 0
 
   statement {
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-    ]
-    resources = [local.secretsmanager_arn]
+    effect  = "Allow"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = compact(concat(
+      local.has_secure_env_vars ? [local.secretsmanager_arn] : [],
+      local.env_vars_secret_arns,
+    ))
   }
 
   dynamic "statement" {

--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -1,21 +1,57 @@
 locals {
+  # Non-sensitive value entries — passed directly as Lambda env vars.
   env_vars_direct = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null
+    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive != true
   }
 
-  env_vars_secret_refs = {
+  # Sensitive value entries — stored as individual Secrets Manager secrets so
+  # the value is never embedded in the Lambda configuration.
+  env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
-    "${name}_SECRET_ARN" => cfg.secret_arn
-    if cfg.secret_arn != null
+    name => cfg.value
+    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive == true
   }
 
-  env_vars_secret_arns = [
-    for name, cfg in var.env_vars :
-    cfg.secret_arn
-    if cfg.secret_arn != null
-  ]
+  # NAME_SECRET_ARN env vars: explicit secret_arn entries + sensitive value secrets.
+  env_vars_secret_refs = merge(
+    { for name, cfg in var.env_vars :
+      "${name}_SECRET_ARN" => cfg.secret_arn
+    if cfg.secret_arn != null },
+    { for name, secret in aws_secretsmanager_secret.sensitive_env_var :
+    "${name}_SECRET_ARN" => secret.arn }
+  )
+
+  # All secret ARNs the Lambda IAM role needs to read.
+  env_vars_secret_arns = concat(
+    [for name, cfg in var.env_vars : cfg.secret_arn if cfg.secret_arn != null],
+    [for _, secret in aws_secretsmanager_secret.sensitive_env_var : secret.arn],
+  )
+
+  uses_secrets_extension = length(local.env_vars_secret_arns) > 0
+}
+
+# Individual Secrets Manager secrets for each sensitive value entry.
+resource "aws_secretsmanager_secret" "sensitive_env_var" {
+  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+
+  name                    = "${local.name}-env-${each.key}"
+  recovery_window_in_days = 0
+  tags                    = var.additional_tags
+}
+
+resource "aws_secretsmanager_secret_version" "sensitive_env_var" {
+  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+
+  secret_id     = aws_secretsmanager_secret.sensitive_env_var[each.key].id
+  secret_string = local.env_vars_sensitive_values[each.key]
+}
+
+# Lifecycle manager always runs on x86_64.
+data "aws_ssm_parameter" "secrets_extension_layer" {
+  count = local.uses_secrets_extension ? 1 : 0
+  name  = "/aws/service/aws-parameters-and-secrets-lambda-extension/x86/latest"
 }
 
 locals {
@@ -41,6 +77,7 @@ resource "aws_lambda_function" "this" {
   role          = aws_iam_role.this.arn
   handler       = "main.main"
   runtime       = "python3.13"
+  layers        = local.uses_secrets_extension ? [data.aws_ssm_parameter.secrets_extension_layer[0].value] : []
 
   # Realistically, this function is just doing a few API calls and then immediately putting the
   # message back onto the queue if it cant doing anything. Like if its waiting for a worker to drain.

--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -1,4 +1,24 @@
 locals {
+  env_vars_direct = {
+    for name, cfg in var.env_vars :
+    name => cfg.value
+    if cfg.secret_arn == null && cfg.value != null
+  }
+
+  env_vars_secret_refs = {
+    for name, cfg in var.env_vars :
+    "${name}_SECRET_ARN" => cfg.secret_arn
+    if cfg.secret_arn != null
+  }
+
+  env_vars_secret_arns = [
+    for name, cfg in var.env_vars :
+    cfg.secret_arn
+    if cfg.secret_arn != null
+  ]
+}
+
+locals {
   lifecycle_code = "${path.module}/ec2-workerpool-lifecycle-manager.zip"
   name           = length("${var.base_name}-lifecycle-manager") <= 64 ? "${var.base_name}-lifecycle-manager" : "${var.base_name}-lcm"
 }
@@ -37,7 +57,7 @@ resource "aws_lambda_function" "this" {
   }
 
   environment {
-    variables = {
+    variables = merge({
       AUTOSCALING_GROUP_ARN         = var.auto_scaling_group_arn
       AUTOSCALING_REGION            = var.aws_region
       SPACELIFT_API_KEY_ID          = var.spacelift_api_credentials.api_key_id
@@ -46,7 +66,7 @@ resource "aws_lambda_function" "this" {
       SPACELIFT_WORKER_POOL_ID      = var.worker_pool_id
       QUEUE_URL                     = aws_sqs_queue.this.url
       LIFECYCLE_HOOK_TIMEOUT        = var.lifecycle_hook_timeout
-    }
+    }, local.env_vars_direct, local.env_vars_secret_refs)
   }
 }
 

--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -3,7 +3,7 @@ locals {
   env_vars_direct = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive != true
+    if cfg.value != null && cfg.sensitive != true
   }
 
   # Sensitive value entries — stored as individual Secrets Manager secrets so
@@ -11,25 +11,22 @@ locals {
   env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null && cfg.sensitive == true
+    if cfg.value != null && cfg.sensitive == true
   }
 
-  # NAME_SECRET_ARN env vars: explicit secret_arn entries + sensitive value secrets.
+  # NAME_SECRET_ARN env vars: explicit secret_env_var_arns entries + sensitive value secrets.
   env_vars_secret_refs = merge(
-    { for name, cfg in var.env_vars :
-      "${name}_SECRET_ARN" => cfg.secret_arn
-    if cfg.secret_arn != null },
-    { for name, secret in aws_secretsmanager_secret.sensitive_env_var :
-    "${name}_SECRET_ARN" => secret.arn }
+    { for name, arn in var.secret_env_var_arns : "${name}_SECRET_ARN" => arn },
+    { for name, secret in aws_secretsmanager_secret.sensitive_env_var : "${name}_SECRET_ARN" => secret.arn }
   )
 
   # All secret ARNs the Lambda IAM role needs to read.
   env_vars_secret_arns = concat(
-    [for name, cfg in var.env_vars : cfg.secret_arn if cfg.secret_arn != null],
+    values(var.secret_env_var_arns),
     [for _, secret in aws_secretsmanager_secret.sensitive_env_var : secret.arn],
   )
 
-  uses_secrets_extension = length(local.env_vars_secret_arns) > 0
+  uses_secrets_extension = length(var.secret_env_var_arns) > 0 || length(local.env_vars_sensitive_values) > 0
 }
 
 # Individual Secrets Manager secrets for each sensitive value entry.

--- a/lifecycle_manager/iam.tf
+++ b/lifecycle_manager/iam.tf
@@ -49,6 +49,15 @@ data "aws_iam_policy_document" "this" {
     actions   = ["ssm:GetParameter"]
     resources = [var.api_key_ssm_parameter_arn]
   }
+
+  dynamic "statement" {
+    for_each = length(local.env_vars_secret_arns) > 0 ? ["USE_SECRETS"] : []
+    content {
+      effect    = "Allow"
+      actions   = ["secretsmanager:GetSecretValue"]
+      resources = local.env_vars_secret_arns
+    }
+  }
 }
 
 resource "aws_iam_role" "this" {

--- a/lifecycle_manager/variables.tf
+++ b/lifecycle_manager/variables.tf
@@ -80,3 +80,14 @@ variable "lifecycle_hook_timeout" {
   description = "Timeout of the ASG lifecycle hook in seconds. The Lambda will stop retrying drain attempts after this period since the hook will have already expired."
   type        = number
 }
+
+variable "env_vars" {
+  description = "Environment variables to pass to the lifecycle manager Lambda function."
+  sensitive   = true
+  type = map(object({
+    value      = optional(string)
+    sensitive  = optional(bool, false)
+    secret_arn = optional(string)
+  }))
+  default = {}
+}

--- a/lifecycle_manager/variables.tf
+++ b/lifecycle_manager/variables.tf
@@ -85,9 +85,14 @@ variable "env_vars" {
   description = "Environment variables to pass to the lifecycle manager Lambda function."
   sensitive   = true
   type = map(object({
-    value      = optional(string)
-    sensitive  = optional(bool, false)
-    secret_arn = optional(string)
+    value     = optional(string)
+    sensitive = optional(bool, false)
   }))
   default = {}
+}
+
+variable "secret_env_var_arns" {
+  description = "Map of environment variable name to an existing Secrets Manager secret ARN."
+  type        = map(string)
+  default     = {}
 }

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ module "autoscaler" {
   spacelift_vpc_subnet_ids         = var.autoscaling_vpc_subnets
   spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
   tracing_mode                     = var.autoscaling_tracing_mode
-  extra_env                        = var.autoscaler_extra_env
+  env_vars                         = var.env_vars
 }
 
 module "lifecycle_manager" {
@@ -59,6 +59,7 @@ module "lifecycle_manager" {
   spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
   spacelift_api_credentials        = var.spacelift_api_credentials
   lifecycle_hook_timeout           = var.lifecycle_hook_timeout
+  env_vars                         = var.env_vars
 }
 
 moved {

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ module "autoscaler" {
   spacelift_vpc_security_group_ids = var.autoscaling_vpc_sg_ids
   tracing_mode                     = var.autoscaling_tracing_mode
   env_vars                         = var.env_vars
+  secret_env_var_arns              = var.secret_env_var_arns
 }
 
 module "lifecycle_manager" {
@@ -60,6 +61,7 @@ module "lifecycle_manager" {
   spacelift_api_credentials        = var.spacelift_api_credentials
   lifecycle_hook_timeout           = var.lifecycle_hook_timeout
   env_vars                         = var.env_vars
+  secret_env_var_arns              = var.secret_env_var_arns
 }
 
 moved {

--- a/secure_strings.tf
+++ b/secure_strings.tf
@@ -1,9 +1,31 @@
 locals {
+  # env_vars entries with a plain/sensitive value — stored in the Secrets Manager bundle for EC2 workers
+  env_vars_with_value = {
+    for name, cfg in var.env_vars :
+    name => cfg.value
+    if cfg.secret_arn == null && cfg.value != null
+  }
+
+  # env_vars entries that reference an existing Secrets Manager secret by ARN
+  env_vars_with_secret_arn = {
+    for name, cfg in var.env_vars :
+    name => cfg.secret_arn
+    if cfg.secret_arn != null
+  }
+
+  env_vars_secret_arns = values(local.env_vars_with_secret_arn)
+
+  # User data lines that fetch each secret_arn entry individually at EC2 startup
+  env_vars_secret_arn_exports = join("\n", [
+    for name, arn in local.env_vars_with_secret_arn :
+    "export ${name}=$(aws secretsmanager get-secret-value --secret-id ${arn} --query SecretString --output text)"
+  ])
+
   byo_secretsmanager  = var.byo_secretsmanager != null
-  has_secure_env_vars = (var.secure_env_vars != null && length(var.secure_env_vars) > 0) || local.byo_secretsmanager
+  has_secure_env_vars = length(local.env_vars_with_value) > 0 || local.byo_secretsmanager
 
   secret_name     = local.byo_secretsmanager ? var.byo_secretsmanager.name : "${local.base_name}-secret"
-  secret_iterator = local.byo_secretsmanager ? { for i in var.byo_secretsmanager.keys : i => "BYO" } : var.secure_env_vars
+  secret_iterator = local.byo_secretsmanager ? { for i in var.byo_secretsmanager.keys : i => "BYO" } : local.env_vars_with_value
 
   secure_env_vars_exports = join(
     "\n",
@@ -21,7 +43,7 @@ resource "validation_warning" "token_or_private_key_in_plaintext" {
   details   = <<EOT
 The 'configuration' parameter seems to contain the 'SPACELIFT_TOKEN' or 'SPACELIFT_POOL_PRIVATE_KEY' environment variables.
 These configuration values are injected in plaintext format into the user data script.
-It is highly recommended to use the 'secure_env_vars' parameter to store sensitive information.
+It is highly recommended to use the 'env_vars' parameter to store sensitive information.
 EOT
 }
 
@@ -39,5 +61,5 @@ resource "aws_secretsmanager_secret_version" "this" {
   count = local.has_secure_env_vars && !local.byo_secretsmanager ? 1 : 0
 
   secret_id     = aws_secretsmanager_secret.this[0].id
-  secret_string = jsonencode(var.secure_env_vars)
+  secret_string = jsonencode(local.env_vars_with_value)
 }

--- a/secure_strings.tf
+++ b/secure_strings.tf
@@ -3,21 +3,15 @@ locals {
   env_vars_with_value = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.secret_arn == null && cfg.value != null
+    if cfg.value != null
   }
 
-  # env_vars entries that reference an existing Secrets Manager secret by ARN
-  env_vars_with_secret_arn = {
-    for name, cfg in var.env_vars :
-    name => cfg.secret_arn
-    if cfg.secret_arn != null
-  }
+  # ARNs for IAM policy and user data come directly from var.secret_env_var_arns
+  env_vars_secret_arns = values(var.secret_env_var_arns)
 
-  env_vars_secret_arns = values(local.env_vars_with_secret_arn)
-
-  # User data lines that fetch each secret_arn entry individually at EC2 startup
+  # User data lines that fetch each secret_env_var_arns entry at EC2 startup
   env_vars_secret_arn_exports = join("\n", [
-    for name, arn in local.env_vars_with_secret_arn :
+    for name, arn in var.secret_env_var_arns :
     "export ${name}=$(aws secretsmanager get-secret-value --secret-id ${arn} --query SecretString --output text)"
   ])
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "env_vars" {
                                                         EC2 workers fetch it at startup; Lambda functions receive a
                                                         NAME_SECRET_ARN env var pointing to the secret.
 EOF
-  sensitive = true
+  sensitive   = true
   type = map(object({
     value      = optional(string)
     sensitive  = optional(bool, false)

--- a/variables.tf
+++ b/variables.tf
@@ -47,20 +47,30 @@ variable "ami_architecture" {
 variable "env_vars" {
   description = <<EOF
   Environment variables to pass to all worker pool components (EC2 workers, autoscaler Lambda, and lifecycle manager Lambda).
-  Each entry can be one of three kinds:
-  - plain:       { value = "..." }                   — passed as-is
-  - sensitive:   { value = "...", sensitive = true }  — redacted in plan/apply output, stored in Secrets Manager for EC2 workers
-  - secret_arn:  { secret_arn = "arn:aws:..." }       — the real value lives in AWS Secrets Manager; Terraform never sees it.
-                                                        EC2 workers fetch it at startup; Lambda functions receive a
-                                                        NAME_SECRET_ARN env var pointing to the secret.
+  Each entry can be one of two kinds:
+  - plain:     { value = "..." }                   — passed as-is
+  - sensitive: { value = "...", sensitive = true }  — redacted in plan/apply output, stored in Secrets Manager for EC2
+                                                      workers and as individual Secrets Manager secrets for Lambda functions.
+  To pass a value that already lives in Secrets Manager use var.secret_env_var_arns instead.
 EOF
   sensitive   = true
   type = map(object({
-    value      = optional(string)
-    sensitive  = optional(bool, false)
-    secret_arn = optional(string)
+    value     = optional(string)
+    sensitive = optional(bool, false)
   }))
   default = {}
+}
+
+variable "secret_env_var_arns" {
+  description = <<EOF
+  Map of environment variable name to an existing Secrets Manager secret ARN.
+  Terraform never reads the secret value. EC2 workers fetch the secret at startup; Lambda functions receive a
+  NAME_SECRET_ARN environment variable pointing to the secret, which is fetched via the AWS Parameters and
+  Secrets Lambda Extension at runtime.
+  The values may be resource-computed ARNs (e.g. aws_secretsmanager_secret.foo.arn).
+EOF
+  type        = map(string)
+  default     = {}
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,15 +44,23 @@ variable "ami_architecture" {
   }
 }
 
-variable "secure_env_vars" {
-  type        = map(string)
-  sensitive   = true
+variable "env_vars" {
   description = <<EOF
-    Secure env vars to be stored in Secrets Manager. Their values will be exported
-    at run time as `export {key}={value}`. This allows you pass the token, private
-    key, or any values securely.
+  Environment variables to pass to all worker pool components (EC2 workers, autoscaler Lambda, and lifecycle manager Lambda).
+  Each entry can be one of three kinds:
+  - plain:       { value = "..." }                   — passed as-is
+  - sensitive:   { value = "...", sensitive = true }  — redacted in plan/apply output, stored in Secrets Manager for EC2 workers
+  - secret_arn:  { secret_arn = "arn:aws:..." }       — the real value lives in AWS Secrets Manager; Terraform never sees it.
+                                                        EC2 workers fetch it at startup; Lambda functions receive a
+                                                        NAME_SECRET_ARN env var pointing to the secret.
 EOF
-  default     = {}
+  sensitive = true
+  type = map(object({
+    value      = optional(string)
+    sensitive  = optional(bool, false)
+    secret_arn = optional(string)
+  }))
+  default = {}
 }
 
 
@@ -332,11 +340,6 @@ variable "autoscaling_configuration" {
   }
 }
 
-variable "autoscaler_extra_env" {
-  description = "Additional environment variables to pass to the autoscaler Lambda function. Values override defaults if keys conflict."
-  type        = map(string)
-  default     = {}
-}
 
 variable "autoscaling_vpc_subnets" {
   description = "List of VPC subnets to use for the autoscaler Lambda function."


### PR DESCRIPTION
## ⚠️ Breaking Change

This PR removes `secure_env_vars` and `autoscaler_extra_env` in favour of a single `env_vars` variable that flows to all worker pool components — EC2 workers, the autoscaler Lambda, and the lifecycle manager Lambda.

Bumps module version to **v7.0.0**.

## What changed

### New `env_vars` variable

Each entry supports three kinds of value:

```hcl
env_vars = {
  # Plain value
  LOG_LEVEL = {
    value = "info"
  }

  # Sensitive value — redacted in plan output, stored in Secrets Manager for EC2 workers
  SPACELIFT_TOKEN = {
    value     = var.worker_pool_config
    sensitive = true
  }

  # Secret ARN — Terraform never sees the value; EC2 workers fetch it at boot,
  # Lambdas receive a NAME_SECRET_ARN env var to retrieve it at runtime
  DB_PASSWORD = {
    secret_arn = "arn:aws:secretsmanager:us-east-1:123456789:secret:prod/db-AbCdEf"
  }
}
```

### How values are handled per component

| Kind | EC2 workers | Autoscaler Lambda | Lifecycle manager Lambda |
|---|---|---|---|
| `value` | Stored in Secrets Manager bundle, exported at boot | Direct env var | Direct env var |
| `secret_arn` | Fetched individually at boot | `NAME_SECRET_ARN` env var + IAM access | `NAME_SECRET_ARN` env var + IAM access |

### IAM changes

- EC2 instance role now also grants `secretsmanager:GetSecretValue` on any `secret_arn` values in `env_vars`
- Autoscaler and lifecycle manager Lambda roles gain `secretsmanager:GetSecretValue` on `secret_arn` values when present

## Migration guide

**`secure_env_vars`:**
```hcl
# Before
secure_env_vars = {
  SPACELIFT_TOKEN            = var.worker_pool_config
  SPACELIFT_POOL_PRIVATE_KEY = var.worker_pool_private_key
}

# After
env_vars = {
  SPACELIFT_TOKEN = {
    value     = var.worker_pool_config
    sensitive = true
  }
  SPACELIFT_POOL_PRIVATE_KEY = {
    value     = var.worker_pool_private_key
    sensitive = true
  }
}
```

**`autoscaler_extra_env`:**
```hcl
# Before
autoscaler_extra_env = {
  SOME_VAR = "some-value"
}

# After
env_vars = {
  SOME_VAR = {
    value = "some-value"
  }
}
```

Users pinning `ref=v6.x.x` are unaffected.