### PR TITLE
feat: Launcher download url configurable

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 7.1.0
+module_version: 7.2.0
 
 tests:
   - name: AMD64-based workerpool

--- a/asg.tf
+++ b/asg.tf
@@ -17,12 +17,14 @@ locals {
     load_custom_certs              = var.selfhosted_configuration.load_custom_certs == null ? "" : var.selfhosted_configuration.load_custom_certs
   })
 
+  binaries_download_base_url = var.binaries_download_base_url != "" ? var.binaries_download_base_url : "https://downloads.${var.domain_name}"
+
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {
-    custom_user_data         = join("\n", [local.secure_env_vars, local.env_vars_secret_arn_exports, var.configuration])
-    domain_name              = var.domain_name
-    poweroff_delay           = var.poweroff_delay
-    region                   = data.aws_region.this.region
-    disable_cloudwatch_agent = var.disable_cloudwatch_agent
+    custom_user_data           = join("\n", [local.secure_env_vars, local.env_vars_secret_arn_exports, var.configuration])
+    binaries_download_base_url = local.binaries_download_base_url
+    poweroff_delay             = var.poweroff_delay
+    region                     = data.aws_region.this.region
+    disable_cloudwatch_agent   = var.disable_cloudwatch_agent
   })
 }
 

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -32,7 +32,7 @@ setup() {
     fi
   fi
 
-  baseURL="https://downloads.${domain_name}/spacelift-launcher$fedrampSuffix"
+  baseURL="${binaries_download_base_url}/spacelift-launcher$fedrampSuffix"
   binaryURL=$(printf "%s-%s" "$baseURL" "$currentArch")
   shaSumURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS")
   shaSumSigURL=$(printf "%s-%s_%s" "$baseURL" "$currentArch" "SHA256SUMS.sig")

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,18 @@ variable "domain_name" {
   default     = "spacelift.io"
 }
 
+variable "binaries_download_base_url" {
+  type        = string
+  description = <<EOF
+  Base URL (scheme + host, no trailing slash, no path) used to download the launcher binary
+  via user_data.
+
+  Defaults to `https://downloads.<var.domain_name>` when unset, preserving backward
+  compatibility for existing callers.
+EOF
+  default     = ""
+}
+
 variable "ec2_instance_type" {
   type        = string
   description = "EC2 instance type for the workers. If an arm64-based AMI is used, this must be an arm64-based instance type."


### PR DESCRIPTION

Make launcher binaries path configurable.
This change preserve backward compatibility and defaults to `https://downloads.${var.domain_name}`



## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [ ] All necessary variables have been defined, with defaults if applicable;
- [ ] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
