### PR TITLE
fix: resolve plan when env_vars values are unknown

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 7.2.0
+module_version: 7.2.1
 
 tests:
   - name: AMD64-based workerpool

--- a/README.md
+++ b/README.md
@@ -69,18 +69,23 @@ For more examples covering specific use cases, please see the [examples director
 - [AMD64 deployment](./examples/amd64/)
 - [ARM64 deployment](./examples/arm64/)
 - [Spot instances for cost optimization](./examples/spot-instances/)
+- [Plain and sensitive environment variables](./examples/env-vars/)
+- [Environment variables from existing secrets](./examples/secret-env-var-arns/)
 - [Autoscaler configuration](./examples/autoscaler/)
 - [Custom S3 package for autoscaler](./examples/autoscaler-custom-s3-package/)
+- [Custom CA bundle for the autoscaler](./examples/autoscaler-ca-bundle/)
+- [Custom EBS throughput for the autoscaler](./examples/autoscaler-custom-ebs-throughput/)
 - [BYO SSM and Secrets Manager](./examples/byo-ssm-secretsmanager-with-autoscaling-and-lifecycle/)
 - [Extra IAM statements](./examples/extra-iam-statements/)
 - [Custom IAM role](./examples/custom-iam-role/)
 - [Self-hosted deployment](./examples/self-hosted/)
+- [Self-hosted deployment with VPC-attached autoscaler](./examples/self-hosted-vpc-autoscaler/)
 
 ## 🔑 Credentials & Environment Variables
 
 ### Using `env_vars` (Recommended)
 
-All environment variables — for EC2 workers, the autoscaler Lambda, and the lifecycle manager Lambda — are passed through a single `env_vars` variable. Each entry supports three kinds of values:
+Environment variables whose values Terraform handles — for EC2 workers, the autoscaler Lambda, and the lifecycle manager Lambda — are passed through a single `env_vars` variable. Each entry supports two kinds of values:
 
 ```hcl
 env_vars = {
@@ -99,22 +104,30 @@ env_vars = {
     value     = var.worker_pool_private_key
     sensitive = true
   }
-
-  # 3. Secret ARN — Terraform never sees the value. EC2 workers fetch
-  #    it individually at startup; Lambda functions receive a
-  #    NAME_SECRET_ARN env var they can use to retrieve it at runtime.
-  DB_PASSWORD = {
-    secret_arn = "arn:aws:secretsmanager:us-east-1:111122223333:secret:prod/db/password-AbCdEf"
-  }
 }
 ```
+
+To pass a value that already lives in Secrets Manager, use the separate `secret_env_var_arns` variable — a map of env var name to secret ARN. Terraform never reads the value, and the ARNs may be resource-computed:
+
+```hcl
+secret_env_var_arns = {
+  DB_PASSWORD = aws_secretsmanager_secret.db_password.arn
+}
+```
+
+See the [secret env var ARNs example](./examples/secret-env-var-arns/) for a full configuration.
 
 **How each kind is handled per component:**
 
 | Kind | EC2 workers | Autoscaler Lambda | Lifecycle manager Lambda |
 |---|---|---|---|
-| `value` | Stored in Secrets Manager bundle, exported at boot | Direct env var | Direct env var |
-| `secret_arn` | Fetched individually at boot via `aws secretsmanager get-secret-value` | `NAME_SECRET_ARN` env var + IAM access | `NAME_SECRET_ARN` env var + IAM access |
+| `env_vars` entry with `value` | Stored in Secrets Manager bundle, exported at boot | Direct env var | Direct env var |
+| `env_vars` entry with `value` + `sensitive = true` | Stored in Secrets Manager bundle, exported at boot | Own Secrets Manager secret + `NAME_SECRET_ARN` env var | Own Secrets Manager secret + `NAME_SECRET_ARN` env var |
+| `secret_env_var_arns` entry | Fetched individually at boot via `aws secretsmanager get-secret-value` | `NAME_SECRET_ARN` env var + IAM access | `NAME_SECRET_ARN` env var + IAM access |
+
+> Note: `sensitive` `env_vars` entries and `secret_env_var_arns` currently take effect on **EC2 workers only**. The Lambdas receive the `NAME_SECRET_ARN` env vars and IAM access, but don't resolve arbitrary secret env vars yet, so for them these are placeholders. This does not affect their operation — they authenticate with the Spacelift API key, delivered separately via SSM. Plain `env_vars` work on all components.
+
+Values in `env_vars` may reference resources created in the same run (for example `spacelift_worker_pool.this.config`) — the module derives its resource counts from the entry names, never from the values, so the plan stays resolvable.
 
 > ❗️ Previous versions of this module used separate `secure_env_vars` and `autoscaler_extra_env` variables. These have been replaced by `env_vars`. The `configuration` variable remains available for non-env-var user data.
 
@@ -144,7 +157,7 @@ byo_ssm = {
 >
 > - Use `env_vars` when you want the module to manage your Secrets Manager resources
 > - Use `byo_secretsmanager` when you have pre-existing Secrets Manager resources or need more control
-> - `env_vars` entries with `secret_arn` (referencing external secrets) are always compatible with `byo_secretsmanager`
+> - `secret_env_var_arns` entries (referencing external secrets) are always compatible with `byo_secretsmanager`
 
 Similarly, when using `byo_ssm` for the autoscaler API credentials, you should not provide `api_key_secret` in the `spacelift_api_credentials` object, as these are mutually exclusive ways to provide the same information:
 

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -8,10 +8,19 @@ locals {
 
   # Sensitive value entries — stored as individual Secrets Manager secrets so
   # the value is never embedded in the Lambda configuration.
+  # The name set is filtered on the `sensitive` flag alone: a value taken from a resource created in
+  # the same run is unknown at plan time, so a `cfg.value != null` filter would make the key set
+  # unknown and break the for_each below.
+  env_vars_sensitive_names = toset([
+    for name, cfg in var.env_vars :
+    name
+    if cfg.sensitive == true
+  ])
+
   env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.value != null && cfg.sensitive == true
+    if cfg.sensitive == true
   }
 
   # NAME_SECRET_ARN env vars: explicit secret_env_var_arns entries + sensitive value secrets.
@@ -29,7 +38,7 @@ locals {
 
 # Individual Secrets Manager secrets for each sensitive value entry.
 resource "aws_secretsmanager_secret" "sensitive_env_var" {
-  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+  for_each = nonsensitive(local.env_vars_sensitive_names)
 
   name                    = "${local.function_name}-env-${each.key}"
   recovery_window_in_days = 0
@@ -37,7 +46,7 @@ resource "aws_secretsmanager_secret" "sensitive_env_var" {
 }
 
 resource "aws_secretsmanager_secret_version" "sensitive_env_var" {
-  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+  for_each = nonsensitive(local.env_vars_sensitive_names)
 
   secret_id     = aws_secretsmanager_secret.sensitive_env_var[each.key].id
   secret_string = local.env_vars_sensitive_values[each.key]

--- a/lifecycle_manager/asg_lifecycle_manager.tf
+++ b/lifecycle_manager/asg_lifecycle_manager.tf
@@ -8,10 +8,19 @@ locals {
 
   # Sensitive value entries — stored as individual Secrets Manager secrets so
   # the value is never embedded in the Lambda configuration.
+  # The name set is filtered on the `sensitive` flag alone: a value taken from a resource created in
+  # the same run is unknown at plan time, so a `cfg.value != null` filter would make the key set
+  # unknown and break the for_each below.
+  env_vars_sensitive_names = toset([
+    for name, cfg in var.env_vars :
+    name
+    if cfg.sensitive == true
+  ])
+
   env_vars_sensitive_values = {
     for name, cfg in var.env_vars :
     name => cfg.value
-    if cfg.value != null && cfg.sensitive == true
+    if cfg.sensitive == true
   }
 
   # NAME_SECRET_ARN env vars: explicit secret_env_var_arns entries + sensitive value secrets.
@@ -29,7 +38,7 @@ locals {
 
 # Individual Secrets Manager secrets for each sensitive value entry.
 resource "aws_secretsmanager_secret" "sensitive_env_var" {
-  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+  for_each = nonsensitive(local.env_vars_sensitive_names)
 
   name                    = "${local.name}-env-${each.key}"
   recovery_window_in_days = 0
@@ -37,7 +46,7 @@ resource "aws_secretsmanager_secret" "sensitive_env_var" {
 }
 
 resource "aws_secretsmanager_secret_version" "sensitive_env_var" {
-  for_each = nonsensitive(toset(keys(local.env_vars_sensitive_values)))
+  for_each = nonsensitive(local.env_vars_sensitive_names)
 
   secret_id     = aws_secretsmanager_secret.sensitive_env_var[each.key].id
   secret_string = local.env_vars_sensitive_values[each.key]

--- a/secure_strings.tf
+++ b/secure_strings.tf
@@ -15,8 +15,14 @@ locals {
     "export ${name}=$(aws secretsmanager get-secret-value --secret-id ${arn} --query SecretString --output text)"
   ])
 
-  byo_secretsmanager  = var.byo_secretsmanager != null
-  has_secure_env_vars = length(local.env_vars_with_value) > 0 || local.byo_secretsmanager
+  byo_secretsmanager = var.byo_secretsmanager != null
+
+  # Derived from the env_vars keys, never from the values. Values may come from a resource created in
+  # the same run (e.g. spacelift_worker_pool.this.config), which makes them unknown at plan time — and
+  # `cfg.value != null` on an unknown value is itself unknown, so anything filtered that way cannot
+  # drive count/for_each ("The count value depends on resource attributes that cannot be determined
+  # until apply"). Map keys are always known, so counting entries keeps the plan resolvable.
+  has_secure_env_vars = length(var.env_vars) > 0 || local.byo_secretsmanager
 
   secret_name     = local.byo_secretsmanager ? var.byo_secretsmanager.name : "${local.base_name}-secret"
   secret_iterator = local.byo_secretsmanager ? { for i in var.byo_secretsmanager.keys : i => "BYO" } : local.env_vars_with_value

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,16 @@ EOF
     sensitive = optional(bool, false)
   }))
   default = {}
+
+  # A sensitive entry gets its own Secrets Manager secret per Lambda, keyed on the entry name alone, so
+  # a missing value surfaces as a provider error at apply time instead of being quietly dropped.
+  # Skipped for values that are still unknown at plan time; those are re-checked during apply.
+  validation {
+    condition = alltrue([
+      for _, cfg in var.env_vars : cfg.value != null if cfg.sensitive == true
+    ])
+    error_message = "Every env_vars entry with 'sensitive = true' must also set 'value'."
+  }
 }
 
 variable "secret_env_var_arns" {


### PR DESCRIPTION
## Description of the change

### Problem
- `env_vars` values that come from a resource created in the same run are unknown at plan time. `cfg.value != null` on an unknown value is itself unknown, so any filter built on it can't be evaluated, which breaks `count` in the root module and `for_each` in both Lambda submodules:

```sh
Error: Invalid count argument
The "count" value depends on resource attributes that cannot be determined until apply.
```
- This blocks the module's documented token-chaining case, e.g. wiring `spacelift_worker_pool.this.config` into `env_vars`.

### Fix

- Derive resource counts from entry names, which are always known at plan time:
  - `has_secure_env_vars` counts `var.env_vars` keys instead of the value-filtered map.
  - New `env_vars_sensitive_names` filters on the `sensitive` flag alone and drives the `for_each` in `autoscaler/` and `lifecycle_manager/`.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue);

## Checklists

### Development

- [X] All necessary variables have been defined, with defaults if applicable;
- [X] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
