### PR TITLE
feat: add network_interfaces passthrough to launch template

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,9 +1,12 @@
 version: 2
-module_version: 8.1.0
+module_version: 8.2.0
 
 tests:
   - name: AMD64-based workerpool
     project_root: examples/amd64
+
+  - name: Network interfaces (public IP via NIC config)
+    project_root: examples/network-interfaces
 
   - name: ARM64-based workerpool
     project_root: examples/arm64

--- a/asg.tf
+++ b/asg.tf
@@ -37,6 +37,7 @@ module "asg" {
   iam_instance_profile_arn = aws_iam_instance_profile.this.arn
   image_id                 = var.ami_id == "" ? data.aws_ami.this[0].id : var.ami_id
   instance_type            = var.ec2_instance_type
+  network_interfaces       = var.network_interfaces
   security_groups          = var.security_groups
   enable_monitoring        = var.enable_monitoring
   instance_refresh         = var.instance_refresh

--- a/examples/network-interfaces/main.tf
+++ b/examples/network-interfaces/main.tf
@@ -1,0 +1,86 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+
+    random = { source = "hashicorp/random" }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+
+  default_tags {
+    tags = {
+      TfModule = "terraform-aws-spacelift-workerpool-on-ec2"
+      TestCase = "network-interfaces"
+    }
+  }
+}
+
+data "aws_vpc" "this" {
+  default = true
+}
+
+data "aws_security_group" "this" {
+  name   = "default"
+  vpc_id = data.aws_vpc.this.id
+}
+
+data "aws_subnets" "this" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+}
+
+resource "random_string" "worker_pool_id" {
+  length  = 26
+  numeric = true
+  # Use special and override special to allow only uppercase letters and numbers
+  # but exclude I, L, O, and U as it does not conform to the regex used by Spacelift
+  special          = true
+  override_special = "ABCDEFGHJKMNPQRSTVWXYZ"
+  lower            = false
+  upper            = false
+}
+
+#### Spacelift worker pool ####
+
+# Example: use network_interfaces to enable associate_public_ip_address.
+# security_groups can still be passed at the top level — the underlying
+# autoscaling module merges them into each network interface entry.
+module "this" {
+  source = "../../"
+
+  worker_pool_id = random_string.worker_pool_id.id
+
+  configuration = <<-EOT
+    export SPACELIFT_SENSITIVE_OUTPUT_UPLOAD_ENABLED=true
+    export SPACELIFT_LAUNCHER_RUN_TIMEOUT=120m
+  EOT
+  env_vars = {
+    SPACELIFT_TOKEN = {
+      value     = "<token-here>"
+      sensitive = true
+    }
+    SPACELIFT_POOL_PRIVATE_KEY = {
+      value     = "<private-key-here>"
+      sensitive = true
+    }
+  }
+
+  security_groups = [data.aws_security_group.this.id]
+  vpc_subnets     = data.aws_subnets.this.ids
+
+  network_interfaces = [
+    {
+      associate_public_ip_address = true
+      delete_on_termination       = true
+    }
+  ]
+
+  manage_log_groups = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -248,6 +248,12 @@ variable "vpc_subnets" {
   description = "List of VPC subnets to use"
 }
 
+variable "network_interfaces" {
+  description = "List of network interface configurations for the launch template. Use to set associate_public_ip_address or other NIC-level options. When set, any security_groups specified at the top level are automatically merged into each network interface entry by the underlying autoscaling module."
+  type        = list(any)
+  default     = null
+}
+
 variable "worker_pool_id" {
   type        = string
   description = "ID (ULID) of the the worker pool."


### PR DESCRIPTION
## Summary

Exposes the `network_interfaces` input variable that the inner [`terraform-aws-modules/autoscaling/aws`](https://registry.terraform.io/modules/terraform-aws-modules/autoscaling/aws/latest) module already supports. This allows callers to configure per-NIC options — most commonly `associate_public_ip_address = true` when deploying worker pools in public subnets that don't have auto-assign public IP enabled at the subnet level.

## Changes

- **`variables.tf`**: new `network_interfaces` variable (`list(any)`, default `null`)
- **`asg.tf`**: passes `network_interfaces` through to `module "asg"`; sets `security_groups = null` when `network_interfaces` is provided (mixing both is invalid in the AWS API)

## Usage

```hcl
module "workerpool" {
  source = "github.com/spacelift-io/terraform-aws-spacelift-workerpool-on-ec2"

  network_interfaces = [
    {
      associate_public_ip_address = true
      security_groups             = [aws_security_group.worker.id]
      delete_on_termination       = true
    }
  ]

  # security_groups is not set when network_interfaces is used
  ...
}
```

## Why not just set `map_public_ip_on_launch` on the subnet?

In some environments the networking team controls subnet-level settings and they may not be configurable by the workerpool caller. The `associate_public_ip_address` flag on the launch template NIC gives callers a way to opt in without requiring subnet changes.