### PR TITLE
feat: pin stable autoscaler release

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,5 +1,5 @@
 version: 2
-module_version: 8.0.0
+module_version: 8.1.0
 
 tests:
   - name: AMD64-based workerpool

--- a/autoscaler/autoscaler.tf
+++ b/autoscaler/autoscaler.tf
@@ -53,13 +53,14 @@ resource "aws_secretsmanager_secret_version" "sensitive_env_var" {
 }
 
 locals {
-  download_folder    = var.worker_pool_id # Unique folder name to avoid race conditions when downloading the archive in parallel
-  architecture       = coalesce(var.autoscaling_configuration.architecture, "amd64")
-  autoscaler_zip     = "${local.download_folder}/ec2-workerpool-autoscaler_linux_${local.architecture}.zip"
-  function_name      = "${var.base_name}-ec2-autoscaler"
-  use_s3_package     = var.autoscaling_configuration.s3_package != null
-  resolve_latest     = var.autoscaling_configuration.version == "latest"
-  autoscaler_version = !local.use_s3_package && local.resolve_latest ? jsondecode(data.http.latest_release[0].response_body).tag_name : var.autoscaling_configuration.version
+  download_folder           = var.worker_pool_id # Unique folder name to avoid race conditions when downloading the archive in parallel
+  architecture              = coalesce(var.autoscaling_configuration.architecture, "amd64")
+  autoscaler_zip            = "${local.download_folder}/ec2-workerpool-autoscaler_linux_${local.architecture}.zip"
+  function_name             = "${var.base_name}-ec2-autoscaler"
+  use_s3_package            = var.autoscaling_configuration.s3_package != null
+  resolve_latest            = var.autoscaling_configuration.version == "latest"
+  stable_autoscaler_version = "v3.0.0"
+  autoscaler_version        = var.autoscaling_configuration.version == "stable" ? local.stable_autoscaler_version : (!local.use_s3_package && local.resolve_latest ? jsondecode(data.http.latest_release[0].response_body).tag_name : var.autoscaling_configuration.version)
 }
 
 # When version = "latest", resolve to a concrete release tag via the GitHub API.

--- a/autoscaler/variables.tf
+++ b/autoscaler/variables.tf
@@ -1,6 +1,6 @@
 variable "autoscaling_configuration" {
   type = object({
-    version             = optional(string, "latest")
+    version             = optional(string, "stable")
     architecture        = optional(string)
     schedule_expression = optional(string)
     max_create          = optional(number)

--- a/docs/upgrade/v7.x-to-v8.0.md
+++ b/docs/upgrade/v7.x-to-v8.0.md
@@ -29,8 +29,8 @@ A worker that picked up a run in the meantime is un-drained and skipped.
 
 ## Requirements
 
-- Autoscaler **≥ v2.8.0** (the first release issuing `TerminateInstanceInAutoScalingGroup`). Automatic when
-  `autoscaling_configuration.version = "latest"`; pinned versions must be bumped to ≥ v2.8.0.
+- Autoscaler **≥ v3.0.0** (the first release issuing `TerminateInstanceInAutoScalingGroup`). Automatic when
+  `autoscaling_configuration.version` is `"stable"` or `"latest"`; pinned versions must be bumped to ≥ v3.0.0.
 
 ## Action required
 

--- a/variables.tf
+++ b/variables.tf
@@ -345,7 +345,7 @@ variable "ca_bundle" {
 variable "autoscaling_configuration" {
   description = <<EOF
   Configuration for the autoscaler Lambda function. If null, the autoscaler will not be deployed. Configuration options are:
-  - version: (optional) Version of the autoscaler to deploy (e.g. "v2.4.0"). Set to "latest" to auto-resolve the newest release via the GitHub API. Set GITHUB_TOKEN in the environment to avoid rate limits.
+  - version: (optional) Version of the autoscaler to deploy (e.g. "v3.0.0"). Defaults to "stable", which is pinned by this module. Set to "latest" to auto-resolve the newest release via the GitHub API. Set GITHUB_TOKEN in the environment to avoid rate limits.
   - architecture: (optional) Instruction set architecture of the autoscaler to use. Can be amd64 or arm64.
   - schedule_expression: (optional) Autoscaler scheduling expression. Default: rate(1 minute).
   - max_create: (optional) The maximum number of instances the utility is allowed to create in a single run.
@@ -360,7 +360,7 @@ variable "autoscaling_configuration" {
   EOF
 
   type = object({
-    version             = optional(string, "latest")
+    version             = optional(string, "stable")
     architecture        = optional(string)
     schedule_expression = optional(string)
     max_create          = optional(number)
@@ -377,8 +377,8 @@ variable "autoscaling_configuration" {
   default = null
 
   validation {
-    condition     = var.autoscaling_configuration == null || try(var.autoscaling_configuration.version == "latest" || startswith(var.autoscaling_configuration.version, "v"), false)
-    error_message = "version must be a release tag starting with \"v\" (e.g. \"v2.5.0\"), or \"latest\"."
+    condition     = var.autoscaling_configuration == null || try(contains(["stable", "latest"], var.autoscaling_configuration.version) || startswith(var.autoscaling_configuration.version, "v"), false)
+    error_message = "version must be a release tag starting with \"v\" (e.g. \"v3.0.0\"), \"stable\", or \"latest\"."
   }
 }
 


### PR DESCRIPTION
## Summary

- Default autoscaler deployments to the module-controlled `stable` alias
- Pin `stable` to autoscaler `v3.0.0` while retaining `latest` and explicit release tags
- Correct the v7-to-v8 upgrade requirement from nonexistent `v2.8.0` to `v3.0.0`
- Bump the module version to `8.1.0`

## Test plan

- `terraform validate`
- `terraform fmt -check -recursive`
- Verified the `v3.0.0` release contains AMD64 and ARM64 Lambda assets
- Verified no `v2.8.0` autoscaler release exists