### PR TITLE
feat: add pre_launch_user_data for root-level host setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,31 @@ Values in `env_vars` may reference resources created in the same run (for exampl
 
 > ❗️ Previous versions of this module used separate `secure_env_vars` and `autoscaler_extra_env` variables. These have been replaced by `env_vars`. The `configuration` variable remains available for non-env-var user data.
 
+### Host setup with `pre_launch_user_data`
+
+`pre_launch_user_data` is a shell script that runs as root during instance boot,
+before the launcher starts. Use it to install packages that aren't in the worker
+AMI:
+
+```hcl
+pre_launch_user_data = <<-EOT
+  dnf install -y git
+EOT
+```
+
+It runs after the custom CA certificates are installed, so package downloads work
+behind a TLS-inspecting proxy, and before the `spacelift` user takes ownership of
+`/opt/spacelift`. If it fails, the instance powers off and the ASG replaces it
+(unless `selfhosted_configuration.power_off_on_error` is `false`).
+
+Environment variables exported here don't reach the launcher - use `env_vars` for
+secrets and `configuration` for plain ones.
+
+> [!NOTE]
+> Runs execute inside a container, so a package installed here is available to the
+> host, not to your Terraform runs. If you need a tool during a run, put it in a
+> custom runner image instead.
+
 ### Using "Bring Your Own" (BYO) Variables
 
 Alternatively, you can use the BYO variables to provide your own pre-created AWS Secrets Manager and SSM resources:

--- a/asg.tf
+++ b/asg.tf
@@ -3,6 +3,7 @@ data "aws_region" "this" {}
 locals {
   selfhosted_user_data = templatefile("${path.module}/user_data/selfhosted.tftpl", {
     custom_user_data               = join("\n", [replace(local.secure_env_vars, "$", "\\$"), replace(local.env_vars_secret_arn_exports, "$", "\\$"), var.configuration])
+    pre_launch_user_data           = var.pre_launch_user_data
     run_launcher_as_spacelift_user = var.selfhosted_configuration.run_launcher_as_spacelift_user == null ? true : var.selfhosted_configuration.run_launcher_as_spacelift_user
     launcher_s3_uri                = var.selfhosted_configuration.s3_uri
     http_proxy_config              = var.selfhosted_configuration.http_proxy_config == null ? "" : var.selfhosted_configuration.http_proxy_config
@@ -21,6 +22,7 @@ locals {
 
   saas_user_data = templatefile("${path.module}/user_data/saas.tftpl", {
     custom_user_data           = join("\n", [local.secure_env_vars, local.env_vars_secret_arn_exports, var.configuration])
+    pre_launch_user_data       = var.pre_launch_user_data
     binaries_download_base_url = local.binaries_download_base_url
     poweroff_delay             = var.poweroff_delay
     region                     = data.aws_region.this.region

--- a/user_data/saas.tftpl
+++ b/user_data/saas.tftpl
@@ -10,6 +10,8 @@ setup() {
   echo "CloudWatch Agent has been disabled" >> /var/log/spacelift/info.log
   %{ endif ~}
 
+  ${pre_launch_user_data}
+
   ${custom_user_data}
 
   currentArch=$(uname -m)

--- a/user_data/selfhosted.tftpl
+++ b/user_data/selfhosted.tftpl
@@ -110,6 +110,11 @@ load_custom_ca_certs () {(
   fi
 )}
 
+run_pre_launch_user_data () {(
+  set -e
+  ${pre_launch_user_data}
+)}
+
 create_spacelift_launcher_script () {(
   set -e
   echo "Creating run-launcher.sh script" >> /var/log/spacelift/info.log
@@ -227,6 +232,16 @@ manage_ssm_by_region () {
 
 disable_cloudwatch_agent
 load_custom_ca_certs
+
+if ! run_pre_launch_user_data; then
+  echo "Pre-launch user data failed" >> /var/log/spacelift/error.log
+  %{ if power_off_on_error ~}
+  sleep 15
+  poweroff
+  exit 1
+  %{ endif ~}
+fi
+
 configure_permissions
 download_launcher
 configure_docker

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,17 @@ EOF
   default     = ""
 }
 
+variable "pre_launch_user_data" {
+  type        = string
+  description = <<EOF
+  Shell script run as root during instance boot, before the Spacelift launcher
+  starts. Use it for host setup such as installing packages that are not in the
+  worker AMI. Environment variables exported here are not passed to the
+  launcher - use `configuration` or `env_vars` for those.
+EOF
+  default     = ""
+}
+
 variable "disable_container_credentials" {
   type        = bool
   description = <<EOF


### PR DESCRIPTION
## Description of the change

Self-hosted customers need to install packages that aren't in the worker AMI (git, most often) and have no supported way to do it. `configuration` looks like the place, but on self-hosted it's inlined into the generated `run-launcher.sh`, which runs as the unprivileged `spacelift` user, so package installs fail. The only alternatives were building a custom AMI or setting `run_launcher_as_spacelift_user = false` and giving up the non-root launcher.

pre_launch_user_data` runs as root during boot, before the launcher starts, on both SaaS and self-hosted. It's placed after the custom CA certificates are installed so downloads work behind a TLS-inspecting proxy, and before the `spacelift` user takes ownership of `/opt/spacelift`. Failures power the instance off so the ASG replaces it, matching the existing launcher-failure path.

Deliberately additive: `configuration` is untouched, so no existing behaviour changes. Reusing it would have meant moving it to boot time and bridging its exports back to the launcher via an `EnvironmentFile`, which breaks silently for anyone who escaped dollar signs for the old heredoc context.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue);
- [x] New feature (non-breaking change that adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] Documentation (a documentation or example fix not affecting the infrastructure managed by this module);

## Checklists

### Development

- [x] All necessary variables have been defined, with defaults if applicable;
- [x] The code is formatted properly;

### Code review

- [ ] The module version is bumped accordingly;
- [ ] Spacelift tests are passing;
- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached;
- [ ] This pull request is no longer marked as "draft";
- [ ] Reviewers have been assigned;
- [ ] Changes have been reviewed by at least one other engineer;
